### PR TITLE
Fix directories variable initialization

### DIFF
--- a/pogo/preferences/common_target.opt
+++ b/pogo/preferences/common_target.opt
@@ -1,7 +1,8 @@
 INSTALL_DIR=$(TANGO_HOME)/bin
 
 # create all directories
-directories := $(shell mkdir -p $(OUTPUT_DIR); for FILE in $(SVC_OBJS); do mkdir -p `dirname $$FILE`; done)
+directories := $(shell mkdir -p $(OUTPUT_DIR); for FILE in $(SVC_OBJS); do mkdir -p `dirname $$FILE`; done; for FILE in $(LIB_OBJS); do mkdir -p `dirname $$FILE`; done)
+ 
 
 #------------------------------------------------------------------------------
 #--  rule: ./*.cpp 


### PR DESCRIPTION
Directories variable is not well created for Library projects or 
multiple projects (DS + Library) since they normally defined `$LIB_OBJS`
instead of `$SVC_OBJS` for building the libraries.

Create directories variable using also `$LIB_OBJS` variable