### PR TITLE
common_target.opt: Avoid dangerous rm -rf logic

### DIFF
--- a/pogo/preferences/common_target.opt
+++ b/pogo/preferences/common_target.opt
@@ -146,9 +146,8 @@ endif
 clean: $(SPECIFIC_CLEAN_TARGET)
 	@echo "Cleaning "$(PROJECT_NAME)
 ifdef OBJDIR
-ifneq ($(OBJDIR),/tmp)
-	rm -rf $(OBJDIR)
-endif
+	rm -f $(OBJDIR)/*.o
+	rmdir $(OBJDIR) 2> /dev/null || true
 endif
 ifeq ($(PROJECT_TYPE),SIMPLE_EXE)
 	rm -f $(OUTPUT_DIR)/$(PROJECT_NAME)


### PR DESCRIPTION
This just caught my eye.

Problems:
- On modern linux systems the temp directory is not only /tmp but maybe
also /var/tmp [1]
- Overrides like the env variable TMPDIR is not honoured
- if OBJDIR points to e.g. /home/$user everything is deleted.

Solution:
- Remove only object files in OBJDIR and then try removing the empty
folder

[1]: https://unix.stackexchange.com/questions/30489/what-is-the-difference-between-tmp-and-var-tmp