### PR TITLE
Improve TAC status report and killing phase in tango_wca script

### DIFF
--- a/scripts/tango.in
+++ b/scripts/tango.in
@@ -121,7 +121,7 @@ case "$1" in
 		fi
 	fi
 	# Start the database device server if needed
-	findproc DataBase
+	findproc DataBaseds
 	if [ "$pid" != "" ];
 	then
 		${ECHO} "Database Server already running, exiting"
@@ -136,7 +136,7 @@ case "$1" in
 
 		# wait for a while before checking status
 		sleep 3
-		findproc DataBase
+		findproc DataBaseds
 		if [ "$pid" = "" ];
 		then
 			${ECHO} "Failed to start Tango database server"
@@ -169,7 +169,7 @@ case "$1" in
 		${ECHO} "MySQL : No process"
 	fi
 
-	findproc DataBase
+	findproc DataBaseds
 	if [ "$pid" != "" ];
 	then
 		${ECHO} "TANGO Database server OK"

--- a/scripts/tango_wca.in
+++ b/scripts/tango_wca.in
@@ -50,7 +50,7 @@ killproc() {
 OS=`uname -s`
 
 #
-# Settings common  to all platforms
+# Settings common to all platforms
 #
 DATABASEDSHOME=@prefix@/bin
 ACCESSCONTROLHOME=@prefix@/bin
@@ -122,7 +122,7 @@ case "$1" in
 		fi
 	fi
 	# Start the database device server if needed
-	findproc DataBase
+	findproc DataBaseds
 	if [ "$pid" != "" ];
 	then
 		${ECHO} "Database Server already running"
@@ -137,7 +137,7 @@ case "$1" in
 
 		# wait for a while before checking status
 		sleep 3
-		findproc DataBase
+		findproc DataBaseds
 		if [ "$pid" = "" ];
 		then
 			${ECHO} "Failed to start Tango database server"
@@ -149,7 +149,7 @@ case "$1" in
 	fi
 	
 	# Start the tango control access server if needed
-	findproc TangogAccessC
+	findproc TangoAccessCont
 	if [ "$pid" != "" ];
 	then
 		${ECHO} "TangoAccessControl Server already running, exiting"
@@ -165,7 +165,7 @@ case "$1" in
 
 		# wait for a while before checking status
 		sleep 2
-		findproc TangoAccessControl
+		findproc TangoAccessCont
 		if [ "$pid" = "" ];
 		then
 			${ECHO} "Failed to start Tango access control server"
@@ -183,7 +183,7 @@ case "$1" in
 	# first shutdown the control access device server
 	'date' >> ${TANGO_LOG}
 	${ECHO} "Stopping TANGO Control Access Server" >> ${TANGO_LOG}
-	killproc TangoAccessControl
+	killproc TangoAccessCont
 	
 	# then shutdown the database device server
 	'date' >> ${TANGO_LOG}
@@ -203,7 +203,7 @@ case "$1" in
 		${ECHO} "MySQL : No process"
 	fi
 
-	findproc DataBase
+	findproc DataBaseds
 	if [ "$pid" != "" ];
 	then
 		${ECHO} "TANGO Database server OK"
@@ -211,7 +211,7 @@ case "$1" in
 		${ECHO} "TANGO Database server : No process"
 	fi
 
-	findproc TangoAccessC
+	findproc TangoAccessCont
 	if [ "$pid" != "" ];
 	then
 		${ECHO} "TANGO Access Control server OK"


### PR DESCRIPTION
Before, at least on Ubuntu 16.04, "tango_wca start" and "tango_wca status"
were complaining that TAC server was not started, even though it was actually
started.
tango_wca script was not able to stop the TAC server on Ubuntu 16.04.
Improve tango and tango_wca scripts to limit the risk to kill another process
containing Database in its executable name.