### PR TITLE
Add rest-server jar

### DIFF
--- a/assets/lib/java/Makefile.am
+++ b/assets/lib/java/Makefile.am
@@ -15,7 +15,8 @@ dist_java_DATA = \
    @JTANGO_JAR@ \
    @ATK_WIDGET_JAR@ \
    @DBBENCH_JAR@ \
-   @JSSH_TERMINAL_JAR@
+   @JSSH_TERMINAL_JAR@ \
+   @REST_SERVER_JAR@
 
 if TANGO_JAVA_ENABLED
 bin_SCRIPTS = \
@@ -31,6 +32,7 @@ bin_SCRIPTS = \
    atkmoni \
    tg_devtest \
    TangoVers \
+   TangoRestServer \
    cvstag
 
 edit = sed \
@@ -67,6 +69,7 @@ atkmoni: $(srcdir)/atkmoni.in
 cvstag: $(srcdir)/cvstag.in
 TangoVers: $(srcdir)/TangoVers.in
 tg_devtest: $(srcdir)/tg_devtest.in
+TangoRestServer: $(srcdir)/TangoRestServer.in
 
 distclean-local: distclean-local-check
 .PHONY: distclean-local-check
@@ -89,7 +92,8 @@ EXTRA_DIST = \
    atkmoni.in \
    cvstag.in \
    tg_devtest.in \
-   TangoVers.in
+   TangoVers.in \
+   TangoRestServer.in
 
 
 # Even though we do not want to compile anything in the

--- a/assets/lib/java/TangoRestServer.in
+++ b/assets/lib/java/TangoRestServer.in
@@ -1,0 +1,13 @@
+#!@SHELL@
+if [ ! $TANGO_HOST ] && [ -f @TANGO_RC_FILE@ ]; then
+   . @TANGO_RC_FILE@
+fi
+
+JAVALIB=@prefix@/share/java
+LOG_HOME=/var/log/TangoRestServer
+LOG_LEVEL=ERROR
+TANGO_REST_SERVER_JAR=$JAVALIB/rest-server.jar
+
+JAVA_OPTS="-mx2G -server -Xshare:off -XX:+UseG1GC -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=$LOG_HOME/TangoRestServer.hprof -XX:-OmitStackTraceInFastThrow"
+
+@JAVA@ $JAVA_OPTS -DTANGO_HOST=$TANGO_HOST -DLOG_HOME=$LOG_HOME -DLOG_LEVEL=$LOG_LEVEL -jar $TANGO_REST_SERVER_JAR $* org.tango.TangoRestServer $* $@

--- a/assets/lib/java/TangoRestServer.in
+++ b/assets/lib/java/TangoRestServer.in
@@ -4,10 +4,10 @@ if [ ! $TANGO_HOST ] && [ -f @TANGO_RC_FILE@ ]; then
 fi
 
 JAVALIB=@prefix@/share/java
-LOG_HOME=/var/log/TangoRestServer
+LOG_HOME=/tmp/log/TangoRestServer
 LOG_LEVEL=ERROR
 TANGO_REST_SERVER_JAR=$JAVALIB/RestServer.jar
 
-JAVA_OPTS="-mx2G -server -Xshare:off -XX:+UseG1GC -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=$LOG_HOME/TangoRestServer.hprof -XX:-OmitStackTraceInFastThrow"
+JAVA_OPTS="-Xmx2G -server -Xshare:off -XX:+UseG1GC -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=$LOG_HOME/TangoRestServer.hprof -XX:-OmitStackTraceInFastThrow"
 
-@JAVA@ $JAVA_OPTS -DTANGO_HOST=$TANGO_HOST -DLOG_HOME=$LOG_HOME -DLOG_LEVEL=$LOG_LEVEL -jar $TANGO_REST_SERVER_JAR rest org.tango.TangoRestServer rest $@
+@JAVA@ $JAVA_OPTS -Duser.dir=$LOG_HOME -DTANGO_HOST=$TANGO_HOST -DLOG_HOME=$LOG_HOME -DLOG_LEVEL=$LOG_LEVEL -jar $TANGO_REST_SERVER_JAR $* org.tango.TangoRestServer $* $@

--- a/assets/lib/java/TangoRestServer.in
+++ b/assets/lib/java/TangoRestServer.in
@@ -6,8 +6,8 @@ fi
 JAVALIB=@prefix@/share/java
 LOG_HOME=/var/log/TangoRestServer
 LOG_LEVEL=ERROR
-TANGO_REST_SERVER_JAR=$JAVALIB/rest-server.jar
+TANGO_REST_SERVER_JAR=$JAVALIB/RestServer.jar
 
 JAVA_OPTS="-mx2G -server -Xshare:off -XX:+UseG1GC -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=$LOG_HOME/TangoRestServer.hprof -XX:-OmitStackTraceInFastThrow"
 
-@JAVA@ $JAVA_OPTS -DTANGO_HOST=$TANGO_HOST -DLOG_HOME=$LOG_HOME -DLOG_LEVEL=$LOG_LEVEL -jar $TANGO_REST_SERVER_JAR $* org.tango.TangoRestServer $* $@
+@JAVA@ $JAVA_OPTS -DTANGO_HOST=$TANGO_HOST -DLOG_HOME=$LOG_HOME -DLOG_LEVEL=$LOG_LEVEL -jar $TANGO_REST_SERVER_JAR rest org.tango.TangoRestServer rest $@

--- a/assets/scripts/tango_wca.in
+++ b/assets/scripts/tango_wca.in
@@ -37,6 +37,34 @@ checkdatabaseds() {
 	fi
 }
 
+startproc() {
+    findproc $1
+	if [ "$pid" != "" ];
+	then
+		${ECHO} "$1 Server is already running"
+		'date' >> ${TANGO_LOG}
+		${ECHO} "$1 Server is already running" >> ${TANGO_LOG}
+	else
+		$2
+
+		${ECHO} "Starting Tango $1 Server"
+		'date' >> ${TANGO_LOG}
+		${ECHO} "Starting Tango $1 Server" >> ${TANGO_LOG}
+
+		# wait for a while before checking status
+		sleep 3
+		findproc $1
+		if [ "$pid" = "" ];
+		then
+			${ECHO} "Failed to start Tango $1 server"
+			'date' >> ${TANGO_LOG}
+			${ECHO} "Failed to start Tango $1 server" >> ${TANGO_LOG}
+			exit 1
+		fi
+		${ECHO} "$rc_done"
+	fi
+}
+
 killproc() {
 	pid=`$PS -e | $GREP "$1" | $SED -e 's/^  *//' -e 's/ .*//'`
 
@@ -52,8 +80,7 @@ OS=`uname -s`
 #
 # Settings common  to all platforms
 #
-DATABASEDSHOME=@prefix@/bin
-ACCESSCONTROLHOME=@prefix@/bin
+SERVERBINHOME=@prefix@/bin
 LD_LIBRARY_PATH=@prefix@/lib:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH
 
@@ -122,65 +149,25 @@ case "$1" in
 		fi
 	fi
 	# Start the database device server if needed
-	findproc DataBase
-	if [ "$pid" != "" ];
-	then
-		${ECHO} "Database Server already running"
-		'date' >> ${TANGO_LOG}
-		${ECHO} "Database Server already running" >> ${TANGO_LOG}
-	else
-		${DATABASEDSHOME}/DataBaseds 2 -ORBendPoint giop:tcp::$TANGO_DB_PORT &
-		
-		${ECHO} "Starting TANGO Database Server"
-		'date' >> ${TANGO_LOG}
-		${ECHO} "Starting TANGO Database Server" >> ${TANGO_LOG}
+	startproc DataBase "${SERVERBINHOME}/DataBaseds 2 -ORBendPoint giop:tcp::$TANGO_DB_PORT &"
 
-		# wait for a while before checking status
-		sleep 3
-		findproc DataBase
-		if [ "$pid" = "" ];
-		then
-			${ECHO} "Failed to start Tango database server"
-			'date' >> ${TANGO_LOG}
-			${ECHO} "Failed to start Tango database server" >> ${TANGO_LOG}
-			exit 1
-		fi
-		${ECHO} "$rc_done"
-	fi
 	
 	# Start the tango control access server if needed
-	findproc TangogAccessC
-	if [ "$pid" != "" ];
-	then
-		${ECHO} "TangoAccessControl Server already running, exiting"
-		'date' >> ${TANGO_LOG}
-		${ECHO} "TangoAccessControl Server already running, exiting" >> ${TANGO_LOG}
-	else
-		export SUPER_TANGO=true
-		${ACCESSCONTROLHOME}/TangoAccessControl 1 &
-		
-		${ECHO} "Starting TANGO Control Access Server"
-		'date' >> ${TANGO_LOG}
-		${ECHO} "Starting TANGO Control Access Server" >> ${TANGO_LOG}
+	export SUPER_TANGO=true
+	startproc TangoAccessControl "${SERVERBINHOME}/TangoAccessControl 1 &"
 
-		# wait for a while before checking status
-		sleep 2
-		findproc TangoAccessControl
-		if [ "$pid" = "" ];
-		then
-			${ECHO} "Failed to start Tango access control server"
-			'date' >> ${TANGO_LOG}
-			${ECHO} "Failed to start Tango access control server" >> ${TANGO_LOG}
-			exit 1
-		fi
-		${ECHO} "$rc_done"
-	fi
+    startproc TangoRestServer "${SERVERBINHOME}/TangoRestServer rest &"
 
     ;;
     stop)
         ${ECHO} "Shutting down TANGO control system"
-		
-	# first shutdown the control access device server
+
+    # first shutdown the rest-server
+	'date' >> ${TANGO_LOG}
+    ${ECHO} "Stopping TangoRestServer" >> ${TANGO_LOG}
+    killproc TangoRestServer
+
+	# second shutdown the control access device server
 	'date' >> ${TANGO_LOG}
 	${ECHO} "Stopping TANGO Control Access Server" >> ${TANGO_LOG}
 	killproc TangoAccessControl
@@ -218,6 +205,14 @@ case "$1" in
 	else
 		${ECHO} "TANGO Access Control server : No process"
 	fi
+
+    findproc TangoRestServer
+    if [ "$pid" != "" ];
+    then
+        ${ECHO} "TangoRestServer server OK"
+    else
+        ${ECHO} "TangoRestServer server : No process"
+    fi
     ;;
     *)
     ${ECHO} "Usage: $0 {start|stop|status|restart}"

--- a/assets/scripts/tango_wca.in
+++ b/assets/scripts/tango_wca.in
@@ -38,14 +38,14 @@ checkdatabaseds() {
 }
 
 startproc() {
-    findproc $1
+	findproc $1
 	if [ "$pid" != "" ];
 	then
 		${ECHO} "$1 Server is already running"
 		'date' >> ${TANGO_LOG}
 		${ECHO} "$1 Server is already running" >> ${TANGO_LOG}
 	else
-		$2
+		$2 &
 
 		${ECHO} "Starting Tango $1 Server"
 		'date' >> ${TANGO_LOG}
@@ -127,7 +127,7 @@ esac
 case "$1" in
     start)
 
-    ${ECHO} "Starting TANGO database"
+	${ECHO} "Starting TANGO database"
 
 	# first check the MySQL  server
 	checkmysql
@@ -149,28 +149,27 @@ case "$1" in
 		fi
 	fi
 	# Start the database device server if needed
-	startproc DataBase "${SERVERBINHOME}/DataBaseds 2 -ORBendPoint giop:tcp::$TANGO_DB_PORT &"
+	startproc DataBase "${SERVERBINHOME}/DataBaseds 2 -ORBendPoint giop:tcp::$TANGO_DB_PORT"
 
 	
 	# Start the tango control access server if needed
 	export SUPER_TANGO=true
-	startproc TangoAccessControl "${SERVERBINHOME}/TangoAccessControl 1 &"
+	startproc TangoAccessC "${SERVERBINHOME}/TangoAccessControl 1"
 
-    startproc TangoRestServer "${SERVERBINHOME}/TangoRestServer rest &"
-
+	startproc TangoRestSer "${SERVERBINHOME}/TangoRestServer rest"
     ;;
     stop)
         ${ECHO} "Shutting down TANGO control system"
 
     # first shutdown the rest-server
 	'date' >> ${TANGO_LOG}
-    ${ECHO} "Stopping TangoRestServer" >> ${TANGO_LOG}
-    killproc TangoRestServer
+	${ECHO} "Stopping TangoRestServer" >> ${TANGO_LOG}
+	killproc TangoRestSer
 
 	# second shutdown the control access device server
 	'date' >> ${TANGO_LOG}
 	${ECHO} "Stopping TANGO Control Access Server" >> ${TANGO_LOG}
-	killproc TangoAccessControl
+	killproc TangoAccessC
 	
 	# then shutdown the database device server
 	'date' >> ${TANGO_LOG}
@@ -206,13 +205,13 @@ case "$1" in
 		${ECHO} "TANGO Access Control server : No process"
 	fi
 
-    findproc TangoRestServer
-    if [ "$pid" != "" ];
-    then
-        ${ECHO} "TangoRestServer server OK"
-    else
-        ${ECHO} "TangoRestServer server : No process"
-    fi
+	findproc TangoRestSer
+	if [ "$pid" != "" ];
+	then
+        	${ECHO} "TangoRestServer server OK"
+	else
+        	${ECHO} "TangoRestServer server : No process"
+	fi
     ;;
     *)
     ${ECHO} "Usage: $0 {start|stop|status|restart}"
@@ -220,4 +219,3 @@ case "$1" in
 esac
 
 exit 0
-

--- a/build.xml
+++ b/build.xml
@@ -54,6 +54,7 @@
                 <filter token="LOGVIEWER_JAR" value="${log-viewer-jar}"/>
                 <filter token="DBBENCH_JAR" value="${dbbench-jar}"/>
                 <filter token="JSSH_TERMINAL_JAR" value="${jssh-terminal-jar}"/>
+                <filter token="REST_SERVER_JAR" value="${rest-server-jar}"/>
             </filterset>
         </copy>
     </target>
@@ -321,6 +322,20 @@
     </target>
     <!-- Pogo -->
 
+
+    <!-- rest-server -->
+    <property name="rest-server-jar" value="rest-server-${rest-server-ver}.jar"/>
+    <property name="rest-server-url" value="${rest-server-root-repo}/tag/rest-server-${rest-server-ver}/${rest-server-jar}"/>
+
+    <target name="-fetch-rest-server">
+        <get src="${rest-server-url}" dest="${workdir}/${rest-server-jar}" skipexisting="true"/>
+    </target>
+
+    <target name="-move-rest-server" depends="-fetch-rest-server">
+        <move file="${workdir}/${rest-server-jar}" todir="${distrdir}/lib/java"/>
+    </target>
+    <!-- Pogo -->
+
     <target name="-fetch-tango-idl">
         <exec executable="git" dir="${workdir}" failonerror="true" failifexecutionfails="true">
             <arg value="clone"/>
@@ -358,6 +373,7 @@
         <antcall target="-move-jssh-terminal"/>
         <antcall target="-move-log-viewer"/>
         <antcall target="-move-pogo"/>
+        <antcall target="-move-rest-server"/>
     </target>
 
     <target name="prepare-lib" depends="-mkdirs">

--- a/build.xml
+++ b/build.xml
@@ -325,7 +325,7 @@
 
     <!-- rest-server -->
     <property name="rest-server-jar" value="rest-server-${rest-server-ver}.jar"/>
-    <property name="rest-server-url" value="${rest-server-root-repo}/tag/rest-server-${rest-server-ver}/${rest-server-jar}"/>
+    <property name="rest-server-url" value="${rest-server-root-repo}/download/rest-server-${rest-server-ver}/${rest-server-jar}"/>
 
     <target name="-fetch-rest-server">
         <get src="${rest-server-url}" dest="${workdir}/${rest-server-jar}" skipexisting="true"/>

--- a/build.xml
+++ b/build.xml
@@ -324,8 +324,8 @@
 
 
     <!-- rest-server -->
-    <property name="rest-server-jar" value="rest-server-${rest-server-ver}.jar"/>
-    <property name="rest-server-url" value="${rest-server-root-repo}/download/rest-server-${rest-server-ver}/${rest-server-jar}"/>
+    <property name="rest-server-jar" value="RestServer-${rest-server-ver}.jar"/>
+    <property name="rest-server-url" value="${rest-server-root-repo}/download/rest-server-${rest-server-ver}/rest-server-${rest-server-ver}.jar"/>
 
     <target name="-fetch-rest-server">
         <get src="${rest-server-url}" dest="${workdir}/${rest-server-jar}" skipexisting="true"/>

--- a/distribution.properties
+++ b/distribution.properties
@@ -20,7 +20,7 @@ rest-server-ver=1.2
 #tool_panels=
 #cppserver
 TangoTest=TangoTest-Release-2.1
-TangoDatabase=DataBase-Release-5.6
+TangoDatabase=Ingvord-add-rest-server
 TangoAccessControl=master
 starter=Starter-7.0
 #doc

--- a/distribution.properties
+++ b/distribution.properties
@@ -2,6 +2,7 @@ src-root-repo=https://github.com/tango-controls
 jtango-root-repo=https://bintray.com/tango-controls/generic/download_file?file_path
 java-root-repo=https://bintray.com/tango-controls/maven/download_file?file_path
 docs-root-repo=https://readthedocs.org/projects/tango-controls/downloads/pdf
+rest-server-root-repo=https://github.com/tango-controls/rest-server/releases
 #lib
 cppTango=9.3.2
 JTango=JTango-9.5.11
@@ -15,6 +16,7 @@ dbbench-ver=1.3
 jssh-terminal-ver=1.11
 log-viewer-ver=2.0.5
 pogo-ver=9.6.16
+rest-server-ver=1.2
 #tool_panels=
 #cppserver
 TangoTest=TangoTest-Release-2.1

--- a/distribution.properties
+++ b/distribution.properties
@@ -26,7 +26,7 @@ rest-server-ver=1.2
 #tool_panels=
 #cppserver
 TangoTest=TangoTest-Release-2.1
-TangoDatabase=Ingvord-add-rest-server
+TangoDatabase=DataBase-Release-5.8
 TangoAccessControl=master
 starter=Starter-7.0
 #doc


### PR DESCRIPTION
This PR adds minimal working configuration of Tango REST server th SourceDistribution. 

Usage after `./configure --prefix=<install-prefix> && make && make install`:

`<intall-prefix>/bin/TangoRestServer rest` -- startup script
`<intall-prefix>/bin/tango_wrest` -- wrapper script script

* to build the distribution clone/download this PR's branch and run `ant build package && cd build/distr`

TangoRestServer is registered in TangoDb as sys/rest/0 with default configuration (no properties are defined)


This PR depends on changes in TangoDatabase, namely: [PR#12](https://github.com/tango-controls/TangoDatabase/pull/12)

To do:
- [x] add reset-server jar
- [x] add TangoRestServer to TangoDatabase: sys/rest/0
- [x] put TangoRestServer script next to DatabaseDs etc
- [x] add TangoRestServer to startup scripts (tango, tango_wca)
