### PR TITLE
PR for #14

### DIFF
--- a/assets/configure.ac
+++ b/assets/configure.ac
@@ -63,7 +63,7 @@ AC_CONFIG_HEADERS(ac_config.h.tmp)
 #      interface numbers in the range from number `CURRENT - AGE' to
 #      `CURRENT'.
 
-VERSION_INFO=11:5:2
+VERSION_INFO=@VERSION_INFO@
 	
 # Checks for programs.
 

--- a/assets/configure.ac
+++ b/assets/configure.ac
@@ -47,24 +47,6 @@ AM_SILENT_RULES([yes])
 AC_CONFIG_HEADERS(ac_config.h.tmp)
 
 
-# -version-info CURRENT[:REVISION[:AGE]]
-# From the libtool documentation (info libtool)
-# So, libtool library versions are described by three integers:
-
-# CURRENT
-#      The most recent interface number that this library implements.
-
-# REVISION
-#      The implementation number of the CURRENT interface.
-
-# AGE
-#      The difference between the newest and oldest interfaces that this
-#      library implements.  In other words, the library implements all the
-#      interface numbers in the range from number `CURRENT - AGE' to
-#      `CURRENT'.
-
-VERSION_INFO=11:5:2
-	
 # Checks for programs.
 
 AC_PROG_CXX

--- a/assets/configure.ac
+++ b/assets/configure.ac
@@ -47,6 +47,24 @@ AM_SILENT_RULES([yes])
 AC_CONFIG_HEADERS(ac_config.h.tmp)
 
 
+# -version-info CURRENT[:REVISION[:AGE]]
+# From the libtool documentation (info libtool)
+# So, libtool library versions are described by three integers:
+
+# CURRENT
+#      The most recent interface number that this library implements.
+
+# REVISION
+#      The implementation number of the CURRENT interface.
+
+# AGE
+#      The difference between the newest and oldest interfaces that this
+#      library implements.  In other words, the library implements all the
+#      interface numbers in the range from number `CURRENT - AGE' to
+#      `CURRENT'.
+
+VERSION_INFO=11:5:2
+	
 # Checks for programs.
 
 AC_PROG_CXX

--- a/assets/lib/cpp/client/Makefile.am
+++ b/assets/lib/cpp/client/Makefile.am
@@ -20,7 +20,7 @@ libtango_la_LIBADD = ../server/libserver.la	\
 
 # We need to set the -version-info for libtool so that libtool will
 # generate the correct .so version
-libtango_la_LDFLAGS=-release $(VERSION)
+libtango_la_LDFLAGS=-version-info $(VERSION_INFO)
 
 AM_CXXFLAGS=-D_TANGO_LIB
 

--- a/assets/lib/cpp/client/Makefile.am
+++ b/assets/lib/cpp/client/Makefile.am
@@ -20,7 +20,7 @@ libtango_la_LIBADD = ../server/libserver.la	\
 
 # We need to set the -version-info for libtool so that libtool will
 # generate the correct .so version
-libtango_la_LDFLAGS=-version-info $(VERSION_INFO)
+libtango_la_LDFLAGS=-release $(VERSION)
 
 AM_CXXFLAGS=-D_TANGO_LIB
 

--- a/build.xml
+++ b/build.xml
@@ -28,6 +28,7 @@
             </fileset>
             <filterset>
                 <filter token="VERSION" value="${cppTango}"/>
+                <filter token="VERSION_INFO" value="${version-info}"/>
             </filterset>
         </copy>
         <copy todir="${distrdir}/doc" overwrite="true">

--- a/distribution.properties
+++ b/distribution.properties
@@ -2,8 +2,12 @@ src-root-repo=https://github.com/tango-controls
 jtango-root-repo=https://bintray.com/tango-controls/generic/download_file?file_path
 java-root-repo=https://bintray.com/tango-controls/maven/download_file?file_path
 docs-root-repo=https://readthedocs.org/projects/tango-controls/downloads/pdf
-#version-info
-version-info=9:3:2
+#VERSION_INFO = current:revision:age
+# where
+#current = tango lib major + $age
+#revision = tango lib patch
+#age = tango lib minor
+version-info=12:2:3
 #lib
 cppTango=9.3.2
 JTango=JTango-9.5.11

--- a/distribution.properties
+++ b/distribution.properties
@@ -2,6 +2,8 @@ src-root-repo=https://github.com/tango-controls
 jtango-root-repo=https://bintray.com/tango-controls/generic/download_file?file_path
 java-root-repo=https://bintray.com/tango-controls/maven/download_file?file_path
 docs-root-repo=https://readthedocs.org/projects/tango-controls/downloads/pdf
+#version-info
+version-info=9:3:2
 #lib
 cppTango=9.3.2
 JTango=JTango-9.5.11


### PR DESCRIPTION
According to [this](https://ftp.gnu.org/old-gnu/Manuals/libtool-1.4.2/html_chapter/libtool_6.html#SEC36)

We should replace -version-info libtool flag with -release. This allows us to manage libtango version from a single variable and removes confusion about IMHO non-trivial libtool versioning.

The obvious change is that we do not have libtango.so.X.Y.Z anymore but rather libtango-X.Y.Z.so:

```
ingvord@hzgc103k:/storage/Projects/org.tango/git/TangoSourceDistribution/build/distr$ ls -al install/lib/
total 291354
drwxrwxrwx 1 root root      4096 Dec  5 17:19 .
drwxrwxrwx 1 root root         0 Dec  5 17:19 ..
-rwxrwxrwx 1 root root      1035 Dec  5 17:19 liblog4tango.la
lrwxrwxrwx 1 root root        50 Dec  5 17:19 liblog4tango.so -> liblog4tango.so.5.0.1
lrwxrwxrwx 1 root root        50 Dec  5 17:19 liblog4tango.so.5 -> liblog4tango.so.5.0.1
-rwxrwxrwx 1 root root    977840 Dec  5 17:19 liblog4tango.so.5.0.1
-rwxrwxrwx 1 root root  78176496 Dec  5 17:19 libtango-9.3.2.so
-rwxrwxrwx 1 root root 219170070 Dec  5 17:19 libtango.a
-rwxrwxrwx 1 root root      1205 Dec  5 17:19 libtango.la
lrwxrwxrwx 1 root root        42 Dec  5 17:19 libtango.so -> libtango-9.3.2.so
drwxrwxrwx 1 root root         0 Dec  5 17:19 pkgconfig
```

I do not know which side effects this might have...
