### PR TITLE
Fix missing separator error in common_target.opt

### DIFF
--- a/assets/pogo/preferences/common_target.opt
+++ b/assets/pogo/preferences/common_target.opt
@@ -163,7 +163,7 @@ endif
 ifeq ($(PROJECT_TYPE),SHARED_LIB)
 	rm -f $(OUTPUT_DIR)/lib$(PROJECT_NAME).so
 endif
-rmdir $(OUTPUT_DIR) 2> /dev/null || true
+	rmdir $(OUTPUT_DIR) 2> /dev/null || true
 
 #------------------------------------------------------------------------------
 #-- install:


### PR DESCRIPTION
Fix the following error (a tab was missing):
common_target.opt:166: *** missing separator.