### PR TITLE
Add logback configuration file (fixes #21)

### DIFF
--- a/assets/lib/java/Makefile.am
+++ b/assets/lib/java/Makefile.am
@@ -4,6 +4,7 @@
 # the link instead of keeping them as links
 
 javadir = $(datadir)/java
+
 dist_java_DATA = \
    @ASTOR_JAR@ \
    @ATK_CORE_JAR@ \
@@ -17,6 +18,12 @@ dist_java_DATA = \
    @DBBENCH_JAR@ \
    @JSSH_TERMINAL_JAR@ \
    @REST_SERVER_JAR@
+
+javaresourcesdir = $(datadir)/tango
+
+dist_javaresources_DATA = \
+   logback.xml \
+   logback-server.xml
 
 if TANGO_JAVA_ENABLED
 bin_SCRIPTS = \
@@ -52,7 +59,6 @@ $(bin_SCRIPTS): Makefile
 	chmod +x $@.tmp
 	chmod a-w $@.tmp
 	mv $@.tmp $@
-
 
 astor: $(srcdir)/astor.in
 jive: $(srcdir)/jive.in

--- a/assets/lib/java/TangoRestServer.in
+++ b/assets/lib/java/TangoRestServer.in
@@ -13,6 +13,7 @@ JAVALIB=@prefix@/share/java
 LOG_HOME=/var/tmp/TangoRestServer
 LOG_LEVEL=ERROR
 TANGO_REST_SERVER_JAR=$JAVALIB/RestServer.jar
+LOGBACK=${TANGO_LOGBACK_SERVER:-@prefix@/share/tango/logback-server.xml}
 
 JAVA_OPTS="-Xmx2G -server -Xshare:off -XX:+UseG1GC -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=$LOG_HOME/TangoRestServer.hprof -XX:-OmitStackTraceInFastThrow"
 
@@ -25,6 +26,7 @@ shift
     -DTANGO_HOST=$TANGO_HOST \
     -DLOG_HOME=$LOG_HOME \
     -DLOG_LEVEL=$LOG_LEVEL \
+    -Dlogback.configurationFile="$LOGBACK" \
     -jar $TANGO_REST_SERVER_JAR \
     "$INSTANCE" \
     org.tango.TangoRestServer \

--- a/assets/lib/java/TangoVers.in
+++ b/assets/lib/java/TangoVers.in
@@ -5,7 +5,10 @@
 LIB_DIR=@prefix@/share/java;	 export LIB_DIR
 CLASSPATH=$LIB_DIR/JTango.jar:$LIB_DIR/Astor.jar
 export CLASSPATH
+LOGBACK=${TANGO_LOGBACK:-@prefix@/share/tango/logback.xml}
 #
 #	Start the java virtual machine
 #
-@JAVA@ admin.astor.tango_release.JTangoVersion
+@JAVA@ \
+    -Dlogback.configurationFile="$LOGBACK" \
+    admin.astor.tango_release.JTangoVersion

--- a/assets/lib/java/astor.in
+++ b/assets/lib/java/astor.in
@@ -61,10 +61,16 @@ export ATK_CLASS
 CLASSPATH=$TANGO_CLASS:$ASTOR_CLASS:$JIVE_CLASS:$ATK_CLASS:$LOGVIEWER:$JSSHTERM:$DBBENCH:$LOG4J
 export CLASSPATH
 
+LOGBACK=${TANGO_LOGBACK:-@prefix@/share/tango/logback.xml}
+
 #---------------------------------------------------------
 #	Start the Astor process
 #---------------------------------------------------------
 #
 
-@JAVA@ -mx128m -DTANGO_HOST=$TANGO_HOST admin.astor.Astor $*
-
+@JAVA@ \
+    -mx128m \
+    -DTANGO_HOST=$TANGO_HOST \
+    -Dlogback.configurationFile="$LOGBACK" \
+    admin.astor.Astor \
+    "$@"

--- a/assets/lib/java/atkmoni.in
+++ b/assets/lib/java/atkmoni.in
@@ -20,10 +20,15 @@ APPLI_MAIN_CLASS=Trend; export APPLI_MAIN_CLASS
 CLASSPATH=$TANGO:$TACO:$TANGOATK
 export CLASSPATH
 echo "CLASSPATH=$CLASSPATH"
+LOGBACK=${TANGO_LOGBACK:-@prefix@/share/tango/logback.xml}
 
 #---------------------------------------------------------
 #       Start the atkmoni process
 #---------------------------------------------------------
 #
 
-@JAVA@ -DTANGO_HOST=$TANGO_HOST $APPLI_PACKAGE.$APPLI_MAIN_CLASS $*
+@JAVA@ \
+    -DTANGO_HOST=$TANGO_HOST \
+    -Dlogback.configurationFile="$LOGBACK" \
+    $APPLI_PACKAGE.$APPLI_MAIN_CLASS \
+    "$@"

--- a/assets/lib/java/atkpanel.in
+++ b/assets/lib/java/atkpanel.in
@@ -18,9 +18,15 @@ ATKPANEL=$LIB_DIR/ATKPanel.jar
 
 CLASSPATH=$ATKPANEL:$TANGOATK:$TANGO
 export CLASSPATH
+LOGBACK=${TANGO_LOGBACK:-@prefix@/share/tango/logback.xml}
 
 #---------------------------------------------------------
 #	Start the atkpanel process
 #---------------------------------------------------------
 
-@JAVA@ -mx128m -DTANGO_HOST=$TANGO_HOST atkpanel.MainPanel $*
+@JAVA@ \
+    -mx128m \
+    -DTANGO_HOST=$TANGO_HOST \
+    -Dlogback.configurationFile="$LOGBACK" \
+    atkpanel.MainPanel \
+    "$@"

--- a/assets/lib/java/atktuning.in
+++ b/assets/lib/java/atktuning.in
@@ -18,9 +18,14 @@ ATKPANEL=$LIB_DIR/ATKTuning.jar
 
 CLASSPATH=$ATKPANEL:$TANGOATK:$TANGO
 export CLASSPATH
+LOGBACK=${TANGO_LOGBACK:-@prefix@/share/tango/logback.xml}
 
 #---------------------------------------------------------
 #	Start the atktuning process
 #---------------------------------------------------------
 
-@JAVA@ -DTANGO_HOST=$TANGO_HOST atktuning.MainPanel $*
+@JAVA@ \
+    -DTANGO_HOST=$TANGO_HOST \
+    -Dlogback.configurationFile="$LOGBACK" \
+    atktuning.MainPanel \
+    "$@"

--- a/assets/lib/java/cvstag.in
+++ b/assets/lib/java/cvstag.in
@@ -16,8 +16,13 @@ POGO_CLASS=$APP_DIR/Pogo.jar;			export POGO_CLASS
 
 CLASSPATH=$POGO_CLASS:$TANGO_CLASS;    export CLASSPATH
 
+LOGBACK=${TANGO_LOGBACK:-@prefix@/share/tango/logback.xml}
+
 #---------------------------------------------------------
 #	Execute java class
 #---------------------------------------------------------
 
-@JAVA@  pogo.make_util.TagModule $@
+@JAVA@ \
+    -Dlogback.configurationFile="$LOGBACK" \
+    pogo.make_util.TagModule \
+    "$@"

--- a/assets/lib/java/devicetree.in
+++ b/assets/lib/java/devicetree.in
@@ -8,6 +8,11 @@ JAVALIB=@prefix@/share/java;
 JAVABIN=@prefix@/share/java;
 CLASSPATH=$JAVALIB/JTango.jar:$JAVALIB/ATKWidget.jar:$JAVALIB/ATKCore.jar:$JAVABIN/Jive.jar:$JAVABIN/ATKPanel.jar:$JAVABIN/DeviceTree.jar
 export CLASSPATH
+LOGBACK=${TANGO_LOGBACK:-@prefix@/share/tango/logback.xml}
 
 echo  Running Device Tree...
-@JAVA@ -DTANGO_HOST=$TANGO_HOST explorer.Main $@
+@JAVA@ \
+    -DTANGO_HOST=$TANGO_HOST \
+    -Dlogback.configurationFile="$LOGBACK" \
+    explorer.Main \
+    "$@"

--- a/assets/lib/java/jdraw.in
+++ b/assets/lib/java/jdraw.in
@@ -20,6 +20,7 @@ APPLI_MAIN_CLASS=JDrawEditorFrame; export APPLI_MAIN_CLASS
 CLASSPATH=$TANGOATK:$TANGO
 export CLASSPATH
 echo "CLASSPATH=$CLASSPATH"
+LOGBACK=${TANGO_LOGBACK:-@prefix@/share/tango/logback.xml}
 
 echo Running Jdraw ...
 
@@ -28,5 +29,7 @@ echo Running Jdraw ...
 #---------------------------------------------------------
 #
 
-@JAVA@ $APPLI_PACKAGE.$APPLI_MAIN_CLASS $@
-
+@JAVA@ \
+    -Dlogback.configurationFile="$LOGBACK" \
+    $APPLI_PACKAGE.$APPLI_MAIN_CLASS \
+    "$@"

--- a/assets/lib/java/jive.in
+++ b/assets/lib/java/jive.in
@@ -15,8 +15,13 @@ ATK=$JAVALIB/ATKCore.jar:$JAVALIB/ATKWidget.jar:$JAVABIN/ATKPanel.jar
 LOGVIEWER=$JAVALIB/LogViewer.jar
 ASTOR=$JAVALIB/Astor.jar:$JAVALIB/tools_panel.jar
 LOG4J=$JAVALIB/log4j.jar
+LOGBACK=${TANGO_LOGBACK:-@prefix@/share/tango/logback.xml}
 
 CLASSPATH=$JAVALIB/JTango.jar:$JAVABIN/Jive.jar:$ATK:$LOGVIEWER:$LOG4J:$ASTOR:.
 export CLASSPATH
 
-@JAVA@ -mx128m -DTANGO_HOST=$TANGO_HOST $applet_name $@
+@JAVA@ \
+    -mx128m \
+    -DTANGO_HOST=$TANGO_HOST \
+    -Dlogback.configurationFile="$LOGBACK" \
+    $applet_name $@

--- a/assets/lib/java/logback-server.xml
+++ b/assets/lib/java/logback-server.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<configuration>
+  <jmxConfigurator />
+
+  <property name="layoutPattern" value="%p %d [%t - %X{deviceName} - %C{1}] %logger{36}.%M:%L - %m%n"/>
+
+  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>${layoutPattern}</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="org.jacorb" level="ERROR" />
+  <logger name="org.tango" level="INFO" />
+
+  <property name="logPath" value="${TANGO_JAVA_LOG_PATH:-/var/tmp/tango/java}"/>
+
+  <appender name="SIFT" class="ch.qos.logback.classic.sift.SiftingAppender">
+    <discriminator class="org.tango.logging.LoggingPerServerDiscriminator"/>
+    <sift>
+      <appender name="FILE-${serverName}" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${logPath}/${serverName}.log</file>
+        <Append>true</Append>
+        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+          <fileNamePattern>${logPath}/${serverName}-%i.log</fileNamePattern>
+          <minIndex>1</minIndex>
+          <maxIndex>3</maxIndex>
+        </rollingPolicy>
+        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+          <MaxFileSize>10MB</MaxFileSize>
+        </triggeringPolicy>
+        <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
+          <layout class="ch.qos.logback.classic.PatternLayout">
+            <pattern>${layoutPattern}</pattern>
+          </layout>
+        </encoder>
+      </appender>
+    </sift>
+  </appender>
+
+  <root level="ERROR">
+    <appender-ref ref="CONSOLE" />
+    <appender-ref ref="SIFT" />
+  </root>
+</configuration>

--- a/assets/lib/java/logback.xml
+++ b/assets/lib/java/logback.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<configuration>
+  <jmxConfigurator />
+
+  <property name="layoutPattern" value="%p %d [%t - %X{deviceName} - %C{1}] %logger{36}.%M:%L - %m%n"/>
+
+  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>${layoutPattern}</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="org.jacorb" level="ERROR" />
+  <logger name="org.tango" level="INFO" />
+
+  <root level="ERROR">
+    <appender-ref ref="CONSOLE" />
+  </root>
+</configuration>

--- a/assets/lib/java/logviewer.in
+++ b/assets/lib/java/logviewer.in
@@ -18,4 +18,10 @@ ATKJAR=$ATKBIN/ATKCore.jar:$ATKBIN/ATKWidget.jar:$ATKBIN/log4j.jar
 CLASSPATH=$JAVALIB/JTango.jar:$TLVBIN/LogViewer.jar:$ATKJAR:.
 export CLASSPATH
 
-@JAVA@ -DTANGO_HOST=$TANGO_HOST $applet_name $*
+LOGBACK=${TANGO_LOGBACK:-@prefix@/share/tango/logback.xml}
+
+@JAVA@ \
+    -DTANGO_HOST=$TANGO_HOST \
+    -Dlogback.configurationFile="$LOGBACK" \
+    $applet_name \
+    "$@"

--- a/assets/lib/java/pogo.in
+++ b/assets/lib/java/pogo.in
@@ -59,6 +59,8 @@ POGO_CLASS=$APP_DIR/Pogo.jar;		export POGO_CLASS
 
 CLASSPATH=$PREF_DIR:$POGO_CLASS;    export CLASSPATH
 
+LOGBACK=${TANGO_LOGBACK:-@prefix@/share/tango/logback.xml}
+
 #---------------------------------------------------------
 #	Start the Pogo process
 #---------------------------------------------------------
@@ -70,4 +72,6 @@ echo "Starting Pogo Appli under $MY_OS.  "
 		-DIN_LANG=$POGO_LANG		\
 		-DEDITOR=$POGO_EDITOR 		\
 		-Dfile.encoding=ISO-8859-1 	\
-		org.tango.pogo.pogo_gui.Pogo $*
+		-Dlogback.configurationFile="$LOGBACK" \
+		org.tango.pogo.pogo_gui.Pogo \
+		"$@"

--- a/assets/lib/java/synopticappli.in
+++ b/assets/lib/java/synopticappli.in
@@ -27,10 +27,16 @@ CLASSPATH=$TACO:$TANGO:$TANGOATK:$ATKPANEL
 export CLASSPATH
 echo "CLASSPATH=$CLASSPATH"
 
+LOGBACK=${TANGO_LOGBACK:-@prefix@/share/tango/logback.xml}
+
 #---------------------------------------------------------
 #       Start the synoptic appli process
 #---------------------------------------------------------
 #
 
-@JAVA@ -mx128m -DTANGO_HOST=$TANGO_HOST $APPLI_PACKAGE.$APPLI_MAIN_CLASS $*
-
+@JAVA@ \
+    -mx128m \
+    -DTANGO_HOST=$TANGO_HOST \
+    -Dlogback.configurationFile="$LOGBACK" \
+    $APPLI_PACKAGE.$APPLI_MAIN_CLASS \
+    "$@"

--- a/assets/lib/java/tg_devtest.in
+++ b/assets/lib/java/tg_devtest.in
@@ -11,6 +11,12 @@ TANGOATK=$JAVALIB/ATKCore.jar:$JAVALIB/ATKWidget.jar
 CLASSPATH=$JAVALIB/JTango.jar:$JAVALIB/Jive.jar:$TANGOATK
 export CLASSPATH
 
+LOGBACK=${TANGO_LOGBACK:-@prefix@/share/tango/logback.xml}
+
 echo   Starting...
 
-@JAVA@  -DTANGO_HOST=$TANGO_HOST jive.ExecDev $1
+@JAVA@ \
+    -DTANGO_HOST=$TANGO_HOST \
+    -Dlogback.configurationFile="$LOGBACK" \
+    jive.ExecDev \
+    "$1"


### PR DESCRIPTION
This PR adds logback configuration (as proposed in #21).
I'll squash the commits after the review.

For now I have few concerns:
* I've used configuration file as provided by @bourtemb in #21. @bourtemb do you think we need ATTRIBUTE and SIFT appenders? Maybe we should just have CONSOLE one?
* I have not set `logback.configurationFile` for TangoRestServer. Logging seems to be handled by tomcat. @Ingvord do we need to change TangoRestServer configuration as well?
* The config is stored in `$PREFIX/share/java/`. I'm not convinced this is the best place. Maybe we should put in in `$PREFIX/share/tango/`. What do you think?
