### PR TITLE
Remove log4tango (change to convenience lib) (#30)

### DIFF
--- a/assets/lib/cpp/log4tango/src/Makefile.am
+++ b/assets/lib/cpp/log4tango/src/Makefile.am
@@ -1,4 +1,4 @@
-lib_LTLIBRARIES = liblog4tango.la
+noinst_LTLIBRARIES = liblog4tango.la
 
 INCLUDES = -I../include -I$(top_srcdir)/include
 


### PR DESCRIPTION
This patch changes log4tango into a libtool convenience library. This way `liblog4tango.so` is no longer generated, but log4tango objects are still compiled and linked into `libtango.so` here:
https://github.com/tango-controls/TangoSourceDistribution/blob/834c5b64e6184ea3b0cd0fd6e380661175b82f28/assets/lib/cpp/client/Makefile.am#L14-L19

I did some tests:

* cppTango built with cmake (with c++11 disabled, otherwise there are 600+ symbols, for move c-tors/assignments, etc.):
```
$ nm -g ~/Documents/prefix/lib/libtango.so.9.3.3  | grep -i log4tango | wc -l
267
```

* TangoSourceDistribution before this patch:
```
$ nm -g /usr/local/lib/libtango.so.9.3.3 | grep -i log4tango | wc -l
63
$ nm -g /usr/local/lib/liblog4tango.so.5.0.1 | grep -i log4tango | wc -l
245
```

* TangoSourceDistribution after the patch
```
$ nm -g /prefix/lib/libtango.so.9.3.3 | grep -i log4tango | wc -l
267
```

* Test program:
```cpp
#include <iostream>
#include <log4tango/OstreamAppender.hh>
int main(int, char**) {
    log4tango::OstreamAppender("test", &std::cout);
    return 0;
}
```

* Shared library:
```
# cmake
$ g++ -I/usr/local/include/tango main.cpp -L/home/tango-cs/Documents/prefix/lib -ltango; echo $?
0

# before
$ g++ -I/usr/local/include/tango main.cpp -L/usr/local/lib -ltango; echo $?
/tmp/cckiMKvg.o: In function `main':
main.cpp:(.text+0x61): undefined reference to `log4tango::OstreamAppender::OstreamAppender(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::ostream*)'
main.cpp:(.text+0x6d): undefined reference to `log4tango::OstreamAppender::~OstreamAppender()'
collect2: error: ld returned 1 exit status
1

# before
$ g++ -I/usr/local/include/tango main.cpp -L/usr/local/lib -llog4tango; echo $?
0

# after
$ g++ -I/usr/local/include/tango main.cpp -L/prefix/lib -ltango; echo $?
0
```

* Static library:
```
# cmake
$ g++ -I/usr/local/include/tango main.cpp /home/tango-cs/Documents/prefix/lib/libtango.a; echo $?
0

# before
$ g++ -I/usr/local/include/tango main.cpp /usr/local/lib/libtango.a; echo $?
/tmp/ccexzHjy.o: In function `main':
main.cpp:(.text+0x61): undefined reference to `log4tango::OstreamAppender::OstreamAppender(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::ostream*)'
main.cpp:(.text+0x6d): undefined reference to `log4tango::OstreamAppender::~OstreamAppender()'
collect2: error: ld returned 1 exit status
1

# before
$ g++ -I/usr/local/include/tango main.cpp /usr/local/lib/liblog4tango.a; echo $?
0

# after
$ g++ -I/usr/local/include/tango main.cpp /prefix/lib/libtango.a; echo $?
0
```