### PR TITLE
Remove log4tango from tango.pc & makefiles; add dummy liblog4tango.so

### DIFF
--- a/assets/cppserver/database/Makefile.am
+++ b/assets/cppserver/database/Makefile.am
@@ -9,8 +9,8 @@ AM_CPPFLAGS = $(ORB_INCLUDE_PREFIX)  $(LIBZMQ_CFLAGS) \
 
 AM_CXXFLAGS= -Wall -D_FORTIFY_SOURCE=2 -O1 -fPIE
 
-LDADD = -L$(top_builddir)/lib/cpp/client -ltango -L$(top_builddir)/lib/cpp/log4tango/src \
-        -llog4tango $(DB_LDFLAGS) \
+LDADD = -L$(top_builddir)/lib/cpp/client -ltango \
+         $(DB_LDFLAGS) \
          $(DB_LDLIBS) $(ZLIB_LDFLAGS) $(ZLIB_LIBS)  $(LIBZMQ_LIBS)
 
 AM_LDFLAGS = -Wl,-z,now -pie

--- a/assets/cppserver/starter/Makefile.am
+++ b/assets/cppserver/starter/Makefile.am
@@ -7,7 +7,6 @@ AM_CPPFLAGS = -I$(top_srcdir)/lib/cpp/server \
            -I$(top_builddir)/lib/cpp/log4tango/include $(LIBZMQ_CFLAGS)
 
 LDADD = -L$(top_builddir)/lib/cpp/client -ltango \
-        -L$(top_builddir)/lib/cpp/log4tango/src -llog4tango \
 		$(LIBZMQ_LIBS)
 
 bin_PROGRAMS=Starter

--- a/assets/cppserver/tangoaccesscontrol/Makefile.am
+++ b/assets/cppserver/tangoaccesscontrol/Makefile.am
@@ -21,6 +21,5 @@ TangoAccessControl_SOURCES=ClassFactory.cpp     		\
 
 
 TangoAccessControl_LDADD = -L$(top_builddir)/lib/cpp/client -ltango \
-        					-L$(top_builddir)/lib/cpp/log4tango/src -llog4tango \
 							$(DB_LDFLAGS) $(DB_LDLIBS) $(LIBZMQ_LIBS) \
 							../AbstractClass/AccessControl/libaccesscontrol.la

--- a/assets/cppserver/tangotest/Makefile.am
+++ b/assets/cppserver/tangotest/Makefile.am
@@ -6,7 +6,6 @@ AM_CPPFLAGS = -I$(top_srcdir)/lib/cpp/client \
            -I$(top_builddir)/lib/cpp/log4tango/include  $(LIBZMQ_CFLAGS)
 
 LDADD = -L$(top_builddir)/lib/cpp/client -ltango \
-        -L$(top_builddir)/lib/cpp/log4tango/src -llog4tango \
  		$(LIBZMQ_LIBS)
 
 bin_PROGRAMS=TangoTest

--- a/assets/lib/cpp/client/Makefile.am
+++ b/assets/lib/cpp/client/Makefile.am
@@ -15,7 +15,7 @@ libtango_la_LIBADD = ../server/libserver.la	\
              ../server/idl/libidl.la \
 		     ../server/jpeg/libjpeg.la \
 		     ../server/jpeg_mmx/libjpeg_mmx.la \
-		     ../log4tango/src/liblog4tango.la \
+		     ../log4tango/src/liblog4tangointernal.la \
 		     $(LIBZMQ_LIBS)
 
 # We need to set the -version-info for libtool so that libtool will

--- a/assets/lib/cpp/log4tango/src/Makefile.am
+++ b/assets/lib/cpp/log4tango/src/Makefile.am
@@ -1,10 +1,10 @@
-noinst_LTLIBRARIES = liblog4tango.la
+noinst_LTLIBRARIES = liblog4tangointernal.la
 
 INCLUDES = -I../include -I$(top_srcdir)/include
 
 noinst_HEADERS = snprintf.c
 
-liblog4tango_la_SOURCES = \
+liblog4tangointernal_la_SOURCES = \
   Appender.cpp \
   AppenderAttachable.cpp \
   LayoutAppender.cpp \
@@ -31,4 +31,8 @@ liblog4tango_la_SOURCES = \
   PortabilityImpl.hh \
   PortabilityImpl.cpp
 
+liblog4tangointernal_la_LDFLAGS = -version-info @LT_VERSION@
+
+lib_LTLIBRARIES = liblog4tango.la
 liblog4tango_la_LDFLAGS = -version-info @LT_VERSION@
+liblog4tango_la_SOURCES =

--- a/assets/lib/cpp/tango.pc.in
+++ b/assets/lib/cpp/tango.pc.in
@@ -5,7 +5,7 @@ includedir=@includedir@
 
 Name: tango
 Description: The tango constrol system library
-Requires: omniDynamic4 >= 4.1.6, omniCOS4, log4tango, libzmq
+Requires: omniDynamic4 >= 4.1.6, omniCOS4, libzmq
 Version: @VERSION@
 Libs: -L${libdir} -ltango
 Cflags: @CPP_ELEVEN@ -I${includedir}/tango

--- a/assets/utils/tango_admin/Makefile.am
+++ b/assets/utils/tango_admin/Makefile.am
@@ -6,7 +6,6 @@ AM_CPPFLAGS = -I$(top_srcdir)/lib/cpp/client \
            -I$(top_builddir)/lib/cpp/log4tango/include $(LIBZMQ_CFLAGS)
 
 LDADD = -L$(top_builddir)/lib/cpp/client -ltango \
-        -L$(top_builddir)/lib/cpp/log4tango/src -llog4tango \
 		$(LIBZMQ_LIBS)
 
 bin_PROGRAMS=tango_admin

--- a/build.xml
+++ b/build.xml
@@ -76,6 +76,13 @@
             <arg value="-B${workdir}/cpp/cmake-build"/>
             <arg value="-DIDL_BASE=${workdir}/idl/install"/>
         </exec>
+        <exec executable="sed" failonerror="true" failifexecutionfails="true">
+            <arg value="-i"/>
+            <arg value="1s/5\.0\.1/5.0.2/;18s/5:1:0/5:2:0/"/>
+            <arg value="${workdir}/cpp/log4tango/configure.in"/>
+        </exec>
+        <exec executable="autoconf" dir="${workdir}/cpp/log4tango" failonerror="true" failifexecutionfails="true">
+        </exec>
     </target>
 
     <target name="-copy-cppTango" depends="-pre-copy-cppTango">


### PR DESCRIPTION
As discussed during meeting at ESRF, following changes has to be made after log4tango has been removed (#30):
* `assets/lib/cpp/tango.pc.in` - remove log4tango as tango dependency from pkg-config file. This file is used by templates generated by Pogo on linux
* `assets/cppserver/*/Makefile.am` - remove `-llog4tango` linker option from all device servers. **NOTE: in each device server source repository there is another makefile which should be aligned as well (but this is out of scope of this change)**
* provide dummy `liblog4tango.so` that exports no symbols at all but is left in 9.3.3 for backwards compatibility. It shall be removed in 9.4.0.

I've tried to install tango with these changes in an empty docker container (so there were no liblog4tango from previous installation). It compiles and installs fine.

Such libraries are generated:
```
root@472df231a8e6:/tango/tango-9.3.3# tree /prefix/lib/
/prefix/lib/
|-- liblog4tango.a
|-- liblog4tango.la
|-- liblog4tango.so -> liblog4tango.so.5.0.1
|-- liblog4tango.so.5 -> liblog4tango.so.5.0.1
|-- liblog4tango.so.5.0.1
|-- libtango.a
|-- libtango.la
|-- libtango.so -> libtango.so.9.3.3
|-- libtango.so.9 -> libtango.so.9.3.3
|-- libtango.so.9.3.3
`-- pkgconfig
    |-- log4tango.pc
    `-- tango.pc

1 directory, 12 files
root@472df231a8e6:/tango/tango-9.3.3# nm -g /prefix/lib/libtango.so.9.3.3 | grep -i log4tango  | wc -l
267
root@472df231a8e6:/tango/tango-9.3.3# nm -g /prefix/lib/liblog4tango.so.5.0.1 | grep -i log4tango | wc -l
0
```

Swapping liblog4tango with a dummy one works without a need to recompile the program:
```
$ g++ -I/usr/local/include/tango main.cpp -ltango -llog4tango -lomniDynamic4 -lCOS4 -lomniORB4 -lomnithread -lzmq; echo $?
0

$ ./a.out; echo $?
0

$ sudo rm /usr/local/lib/liblog4tango.*

$ ./a.out; echo $?
./a.out: error while loading shared libraries: liblog4tango.so.5: cannot open shared object file: No such file or directory
127

$ sudo cp ~/TangoSourceDistribution/build/lib/liblog4tango.* /usr/local/lib/

$ ./a.out; echo $?
./a.out: symbol lookup error: /usr/local/lib/libtango.so.9: undefined symbol: _ZTIN9log4tango14LayoutAppenderE
127

$ sudo rm /usr/local/lib/libtango.*
$ sudo cp ~/TangoSourceDistribution/build/lib/libtango.* /usr/local/lib/

$ ./a.out; echo $?
0
```