### PR TITLE
Remove my.cnf config file (tango-controls/TangoDatabase#16)

### DIFF
--- a/assets/README
+++ b/assets/README
@@ -62,7 +62,7 @@ This source code release contains :
 
 (1) Tango C++ library source files and java library and application jar files
 
-(2) The Tango database device server source files and the database configuration files (.my.cnf).
+(2) The Tango database device server source files.
 
 (3) The Jive application. 
 
@@ -264,6 +264,14 @@ The configure options "--with-mysql-admin" and "--with-mysql-admin-passwd"
 allow you to select which database user configure will use.
 You can also use the user and password entries of the my.cnf file
 to set-up your connection to the database.
+
+Note: It is recommended to setup the database to use latin1 character set.
+Especially, any other character set with characters longer than 3 bytes
+will not work. Character set can be specified in my.cnf configuration file:
+
+[mysqld]
+character_set_server=latin1
+collation_server=latin1_swedish_ci
 
 To disable any access to the database use the --disable-dbcreate option.
 

--- a/assets/configure.ac
+++ b/assets/configure.ac
@@ -481,7 +481,6 @@ AC_OUTPUT(Makefile
 	  cppserver/database/Makefile
 	  cppserver/database/create_db.sql	
 	  cppserver/database/create_db.sh
-	  cppserver/database/my.cnf
 	  cppserver/database/stored_proc.sql
 	  cppserver/database/create_db_tables.sql
 	  cppserver/database/update_db.sh

--- a/assets/cppserver/database/Makefile.am
+++ b/assets/cppserver/database/Makefile.am
@@ -31,7 +31,7 @@ DataBaseds_SOURCES=ClassFactory.cpp          \
 if TANGO_DB_CREATE_ENABLED
 
 dbdir=${pkgdatadir}/db
-db_DATA=create_db.sh create_db.sql my.cnf create_db_tables.sql stored_proc.sql update_db.sh update_db.sql update_db8.sql update_db7.sql rem_history.sql
+db_DATA=create_db.sh create_db.sql create_db_tables.sql stored_proc.sql update_db.sh update_db.sql update_db8.sql update_db7.sql rem_history.sql
 
 ## This is to make sure that the create-db script is run on each make all.
 ## See create_db.sh for more information.
@@ -40,7 +40,7 @@ all-local: .force
 
 endif
 
-EXTRA_DIST    = create_db.sh.in create_db.sql.in my.cnf.in create_db_tables.sql.in stored_proc.sql.in \
+EXTRA_DIST    = create_db.sh.in create_db.sql.in create_db_tables.sql.in stored_proc.sql.in \
                 update_db.sh.in update_db8.sql.in update_db7.sql.in update_db.sql.in rem_history.sql.in
 
 .force:


### PR DESCRIPTION
In tango-controls/TangoDatabase#16 it was agreed that we could remove my.cnf file, as Tango has no special requirements regarding database configuration. The only exception is that Tango does not work with utf8bm4 charset (a note was added to the readme).