### PR TITLE
Add CMake opt files (#34)

### DIFF
--- a/assets/pogo/preferences/Makefile.am
+++ b/assets/pogo/preferences/Makefile.am
@@ -7,10 +7,12 @@ edit = sed \
 
 preferencesdir   		= $(datadir)/pogo/preferences
 
-dist_preferences_DATA 	= common_target.opt 
+dist_preferences_DATA = common_target.opt \
+                        cmake_common_target.opt
 
 nodist_preferences_DATA   = Pogo.site_properties \
-				 tango.opt
+                            tango.opt \
+                            cmake_tango.opt
 
 
 $(nodist_preferences_DATA): Makefile
@@ -24,7 +26,9 @@ $(nodist_preferences_DATA): Makefile
 CLEANFILES = $(nodist_preferences_DATA)
 Pogo.site_properties: $(srcdir)/Pogo.site_properties.in
 tango.opt: $(srcdir)/tango.opt.in
+cmake_tango.opt: $(srcdir)/cmake_tango.opt.in
 
 EXTRA_DIST = \
    Pogo.site_properties.in \
-   tango.opt.in
+   tango.opt.in \
+   cmake_tango.opt.in

--- a/assets/pogo/preferences/cmake_common_target.opt
+++ b/assets/pogo/preferences/cmake_common_target.opt
@@ -1,0 +1,14 @@
+
+#
+#	Set library directories
+#
+link_directories(${USER_LIB_DIR} ${TANGO_LIB_HOME})
+
+#
+#	Compile and link
+#
+message("SERVER_NAME=${SERVER_NAME}")
+message("SERVER_SRC=${SERVER_SRC}")
+add_executable(${SERVER_NAME} ${SERVER_SRC})
+target_link_libraries(${SERVER_NAME} ${USER_LIBS} ${TANGO_LIBS})
+

--- a/assets/pogo/preferences/cmake_tango.opt.in
+++ b/assets/pogo/preferences/cmake_tango.opt.in
@@ -1,0 +1,65 @@
+#
+#	Set default PATH
+#
+set(EXECUTABLE_OUTPUT_PATH "${CMAKE_BINARY_DIR}/bin/")
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${EXECUTABLE_OUTPUT_PATH})
+
+if(DEFINED TANGO_HOME)
+	message("-DTANGO_HOME specified in the command line")
+else()
+	set(TANGO_HOME $ENV{TANGO_HOME})
+endif(DEFINED TANGO_HOME)
+
+if(DEFINED TANGO_HOME)
+	message("TANGO_HOME = ${TANGO_HOME}")
+else()
+	set(TANGO_HOME @prefix@)
+endif(DEFINED TANGO_HOME)
+
+set(ENV{PKG_CONFIG_PATH} "${TANGO_HOME}/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}")
+
+if(DEFINED OMNI_HOME)
+	message("-DOMNI_HOME specified in the command line")
+else()
+	set(OMNI_HOME $ENV{OMNI_HOME})
+endif(DEFINED OMNI_HOME)
+if(DEFINED OMNI_HOME)
+	message("OMNI_HOME = ${OMNI_HOME}")
+	set(ENV{PKG_CONFIG_PATH} "${OMNI_HOME}/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}")
+endif(DEFINED OMNI_HOME)
+
+
+if(DEFINED ZMQ_HOME)
+	message("-DZMQ_HOME specified in the command line")
+else()
+	set(ZMQ_HOME $ENV{ZMQ_HOME})
+endif(DEFINED ZMQ_HOME)
+if(DEFINED ZMQ_HOME)
+	message("ZMQ_HOME = ${ZMQ_HOME}")
+	set(ENV{PKG_CONFIG_PATH} "${ZMQ_HOME}/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}")
+endif(DEFINED ZMQ_HOME)
+
+#
+# Compiler and linker flags
+#
+include(CheckCXXCompilerFlag)
+CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
+CHECK_CXX_COMPILER_FLAG("-std=c++0x" COMPILER_SUPPORTS_CXX0X)
+if(COMPILER_SUPPORTS_CXX11)
+	set(C++11_FLAGS "-std=c++11")
+elseif(COMPILER_SUPPORTS_CXX0X)
+	set(C++11_FLAGS "-std=c++0x")
+else()
+        message(STATUS "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support.")
+endif()
+
+set(CMAKE_CXX_FLAGS "${CXXFLAGS_USER}  ${CMAKE_CXX_FLAGS} ${C++11_FLAGS}")
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(PKG_TANGO REQUIRED tango)
+
+set(TANGO_INCLUDES ${PKG_TANGO_INCLUDE_DIRS})
+set(TANGO_LIBS ${PKG_TANGO_LIBRARIES})
+set(TANGO_LIB_HOME ${PKG_TANGO_LIBRARY_DIRS})
+
+add_definitions (${PKG_TANGO_CFLAGS_OTHER})

--- a/assets/pogo/preferences/cmake_tango.opt.in
+++ b/assets/pogo/preferences/cmake_tango.opt.in
@@ -40,20 +40,9 @@ if(DEFINED ZMQ_HOME)
 endif(DEFINED ZMQ_HOME)
 
 #
-# Compiler and linker flags
+# Compiler flags
 #
-include(CheckCXXCompilerFlag)
-CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
-CHECK_CXX_COMPILER_FLAG("-std=c++0x" COMPILER_SUPPORTS_CXX0X)
-if(COMPILER_SUPPORTS_CXX11)
-	set(C++11_FLAGS "-std=c++11")
-elseif(COMPILER_SUPPORTS_CXX0X)
-	set(C++11_FLAGS "-std=c++0x")
-else()
-        message(STATUS "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support.")
-endif()
-
-set(CMAKE_CXX_FLAGS "${CXXFLAGS_USER}  ${CMAKE_CXX_FLAGS} ${C++11_FLAGS}")
+set(CMAKE_CXX_FLAGS "${CXXFLAGS_USER}  ${CMAKE_CXX_FLAGS}")
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(PKG_TANGO REQUIRED tango)

--- a/assets/pogo/preferences/tango.opt.in
+++ b/assets/pogo/preferences/tango.opt.in
@@ -1,6 +1,26 @@
 # vim: set filetype=make:
 
 #------------------------------------------------------------------------------
+#-- gcc version
+#------------------------------------------------------------------------------
+GCC_MAJOR_VERSION_GT4 := $(shell expr `c++ -dumpversion | cut -f1 -d.` \> 4)
+GCC_MAJOR_VERSION_LT6 := $(shell expr `c++ -dumpversion | cut -f1 -d.` \< 6)
+GCC_MAJOR_VERSION_EQ4 := $(shell expr `c++ -dumpversion | cut -f1 -d.` \== 4)
+GCC_MAJOR_VERSION_EQ6 := $(shell expr `c++ -dumpversion | cut -f1 -d.` \== 6)
+GCC_MINOR_VERSION_GTEQ3 := $(shell expr `c++ -dumpversion | cut -f2 -d.` \>= 3)
+GCC_MINOR_VERSION_LT1 := $(shell expr `c++ -dumpversion | cut -f2 -d.` \< 1)
+
+ifeq ($(GCC_MAJOR_VERSION_LT6),1)
+    CXX11 = -std=c++0x
+else
+    ifeq ($(GCC_MAJOR_VERSION_EQ6),1)
+        ifeq ($(GCC_MINOR_VERSION_LT1),1)
+            CXX11 = -std=c++0x
+        endif
+    endif
+endif
+
+#------------------------------------------------------------------------------
 #-- TANGO_HOME
 #------------------------------------------------------------------------------
 ifndef TANGO_HOME
@@ -144,7 +164,7 @@ ifdef CXXFLAGS_USR
 	CXXFLAGS_USER = $(CXXFLAGS_USR)
 endif
 
-CXXFLAGS += -D_REENTRANT -W $(INCLUDE_DIRS) $(CXXFLAGS_USER) -Dlinux
+CXXFLAGS += -D_REENTRANT -W $(INCLUDE_DIRS) $(CXXFLAGS_USER) $(CXX11) -Dlinux
 
 #------------------------------------------------------------------------------
 #-- CFLAGS

--- a/assets/pogo/preferences/tango.opt.in
+++ b/assets/pogo/preferences/tango.opt.in
@@ -1,21 +1,6 @@
 # vim: set filetype=make:
 
 #------------------------------------------------------------------------------
-#-- gcc version
-#------------------------------------------------------------------------------
-GCC_MAJOR_VERSION_GT4 := $(shell expr `c++ -dumpversion | cut -f1 -d.` \> 4)
-GCC_MAJOR_VERSION_EQ4 := $(shell expr `c++ -dumpversion | cut -f1 -d.` \== 4)
-GCC_MINOR_VERSION_GTEQ3 := $(shell expr `c++ -dumpversion | cut -f2 -d.` \>= 3)
-ifeq ($(GCC_MAJOR_VERSION_GT4),1)
-    CXX11 = -std=c++0x
-else
-    ifeq ($(GCC_MAJOR_VERSION_EQ4),1)
-        ifeq ($(GCC_MINOR_VERSION_GTEQ3),1)
-            CXX11 = -std=c++0x
-        endif
-    endif
-endif
-#------------------------------------------------------------------------------
 #-- TANGO_HOME
 #------------------------------------------------------------------------------
 ifndef TANGO_HOME
@@ -159,7 +144,7 @@ ifdef CXXFLAGS_USR
 	CXXFLAGS_USER = $(CXXFLAGS_USR)
 endif
 
-CXXFLAGS += -D_REENTRANT -W $(INCLUDE_DIRS) $(CXXFLAGS_USER) $(CXX11)  -Dlinux
+CXXFLAGS += -D_REENTRANT -W $(INCLUDE_DIRS) $(CXXFLAGS_USER) -Dlinux
 
 #------------------------------------------------------------------------------
 #-- CFLAGS


### PR DESCRIPTION
Add cmake_common_target.opt and cmake_tango.opt to the distribution
in order to be able to generate CMakeLists.txt files for Device
Servers from Pogo.