### PR TITLE
Add the source of the documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ before_script:
       libzmq3-dev
       libmysqlclient-dev
       ant
-
+  - sudo apt install -y python python-pip
+  - pip install --user Sphinx~=1.0 ipython~=5.0
 script:
   - ant build package
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ The following packages must be installed if one wants to build the TangoSourceDi
 
 `sudo apt-get install -y build-essential cmake autoconf libtool ant omniidl libomniorb4-dev libcos4-dev libomnithread3-dev libzmq3-dev`
 
+To build the documentation, additional dependencies must be installed:
+
+```
+sudo apt install -y python python-pip
+pip install Sphinx ipython
+```
+
 Once the above requirements are satisified, do `ant build package`
 
 The good output looks like this:

--- a/assets/README
+++ b/assets/README
@@ -477,7 +477,10 @@ e - Restart your database server(s)
 8 - DOCUMENTATION
 -----------------
 
-Don't forget to READ THE MANUAL (in doc/tango.pdf) !
+The full documentation for Tango is available at https://tango-controls.readthedocs.io
+If Tango is properly installed at your site, a copy of the documentation should be available in
+<install_prefix>/share/doc/tango
+You can also look at the Tango web site at https://www.tango-controls.org
 
 9 - REMARKS
 -----------

--- a/assets/doc/Makefile.am
+++ b/assets/doc/Makefile.am
@@ -1,22 +1,12 @@
-
-DOCS = tango-@DOCS_VER@.pdf
 SUBDIRS = man
 
 install-data-local:
 	mkdir -p $(DESTDIR)/$(docdir)
-	for file in $(DOCS); do \
-	    cp -f $(srcdir)/$$file $(DESTDIR)/$(docdir)/$$file; \
-		chmod u+w $(DESTDIR)/$(docdir)/$$file; \
-	done;                                        
+	cp -r $(srcdir)/html $(DESTDIR)/$(docdir)/
 
 uninstall-local:
-	for file in $(DOCS);do \
-		rm $(DESTDIR)/$(docdir)/$$file; \
-	done;
+	rm -rf $(DESTDIR)/$(docdir)/html
 
 dist-hook:
-	for file in $(DOCS); do        \
-	   cp $(top_srcdir)/doc/$$file $(distdir)/$$file;       \
-	done; \
-	cp -R $(top_srcdir)/doc/src $(distdir); \
-	rm -rf `find $(distdir) -name .svn`
+	cp -r $(top_srcdir)/doc/html $(distdir)/
+	cp -r $(top_srcdir)/doc/src $(distdir)/

--- a/assets/doc/man/astor.1
+++ b/assets/doc/man/astor.1
@@ -9,10 +9,10 @@ Graphical tool to administrate a Tango control system
 .SH "AUTHOR"
 The Tango team
 .SH "SEE ALSO"
-The full documentation for
-.B Tango
-is maintained as a pdf file.  If 
-.B Tango
-is properly installed at your site, this pdf file should be available in <tango_install_dir>/doc.
+The full documentation for \fBTango\fR is available at
+\fBhttps://tango-controls.readthedocs.io\fR.
+If \fBTango\fR is properly installed at your site,
+a copy of the documentation should be available in
+\fI/<install_prefix>/share/doc/tango\fR.
 You can also look at the Tango web site at 
-.B http://www.tango-controls.org.
+.B https://www.tango-controls.org.

--- a/assets/doc/man/atkmoni.1
+++ b/assets/doc/man/atkmoni.1
@@ -14,10 +14,10 @@ displayed allowing the user to select devices and attributes.
 .SH "AUTHOR"
 The Tango team
 .SH "SEE ALSO"
-The full documentation for
-.B Tango
-is maintained as a pdf file.  If 
-.B Tango
-is properly installed at your site, this pdf file should be available in <tango_install_dir>/doc.
+The full documentation for \fBTango\fR is available at
+\fBhttps://tango-controls.readthedocs.io\fR.
+If \fBTango\fR is properly installed at your site,
+a copy of the documentation should be available in
+\fI/<install_prefix>/share/doc/tango\fR.
 You can also look at the Tango web site at 
-.B http://www.tango-controls.org.
+.B https://www.tango-controls.org.

--- a/assets/doc/man/atkpanel.1
+++ b/assets/doc/man/atkpanel.1
@@ -14,10 +14,10 @@ Specify the device name. If omitted, a window pops-up asking for a device name
 .SH "AUTHOR"
 The Tango team
 .SH "SEE ALSO"
-The full documentation for
-.B Tango
-is maintained as a pdf file.  If 
-.B Tango
-is properly installed at your site, this pdf file should be available in <tango_install_dir>/doc.
+The full documentation for \fBTango\fR is available at
+\fBhttps://tango-controls.readthedocs.io\fR.
+If \fBTango\fR is properly installed at your site,
+a copy of the documentation should be available in
+\fI/<install_prefix>/share/doc/tango\fR.
 You can also look at the Tango web site at 
-.B http://www.tango-controls.org.
+.B https://www.tango-controls.org.

--- a/assets/doc/man/atktuning.1
+++ b/assets/doc/man/atktuning.1
@@ -15,10 +15,10 @@ Do not display command button(s)
 .SH "AUTHOR"
 The Tango team
 .SH "SEE ALSO"
-The full documentation for
-.B Tango
-is maintained as a pdf file.  If 
-.B Tango
-is properly installed at your site, this pdf file should be available in <tango_install_dir>/doc.
+The full documentation for \fBTango\fR is available at
+\fBhttps://tango-controls.readthedocs.io\fR.
+If \fBTango\fR is properly installed at your site,
+a copy of the documentation should be available in
+\fI/<install_prefix>/share/doc/tango\fR.
 You can also look at the Tango web site at 
-.B http://www.tango-controls.org.
+.B https://www.tango-controls.org.

--- a/assets/doc/man/devicetree.1
+++ b/assets/doc/man/devicetree.1
@@ -14,10 +14,10 @@ Start devicetree in "run" mode for the panel described in \fIfile_name\fR
 .SH "AUTHOR"
 The Tango team
 .SH "SEE ALSO"
-The full documentation for
-.B Tango
-is maintained as a pdf file.  If 
-.B Tango
-is properly installed at your site, this pdf file should be available in <tango_install_dir>/doc.
+The full documentation for \fBTango\fR is available at
+\fBhttps://tango-controls.readthedocs.io\fR.
+If \fBTango\fR is properly installed at your site,
+a copy of the documentation should be available in
+\fI/<install_prefix>/share/doc/tango\fR.
 You can also look at the Tango web site at 
-.B http://www.tango-controls.org.
+.B https://www.tango-controls.org.

--- a/assets/doc/man/jdraw.1
+++ b/assets/doc/man/jdraw.1
@@ -13,10 +13,10 @@ File describing the synoptic.
 .SH "AUTHOR"
 The Tango team
 .SH "SEE ALSO"
-The full documentation for
-.B Tango
-is maintained as a pdf file.  If 
-.B Tango
-is properly installed at your site, this pdf file should be available in <tango_install_dir>/doc.
+The full documentation for \fBTango\fR is available at
+\fBhttps://tango-controls.readthedocs.io\fR.
+If \fBTango\fR is properly installed at your site,
+a copy of the documentation should be available in
+\fI/<install_prefix>/share/doc/tango\fR.
 You can also look at the Tango web site at 
-.B http://www.tango-controls.org.
+.B https://www.tango-controls.org.

--- a/assets/doc/man/jive.1
+++ b/assets/doc/man/jive.1
@@ -13,10 +13,10 @@ Read only mode (No write access to database allowed)
 .SH "AUTHOR"
 The Tango team
 .SH "SEE ALSO"
-The full documentation for
-.B Tango
-is maintained as a pdf file.  If 
-.B Tango
-is properly installed at your site, this pdf file should be available in <tango_install_dir>/doc.
+The full documentation for \fBTango\fR is available at
+\fBhttps://tango-controls.readthedocs.io\fR.
+If \fBTango\fR is properly installed at your site,
+a copy of the documentation should be available in
+\fI/<install_prefix>/share/doc/tango\fR.
 You can also look at the Tango web site at 
-.B http://www.tango-controls.org.
+.B https://www.tango-controls.org.

--- a/assets/doc/man/logviewer.1
+++ b/assets/doc/man/logviewer.1
@@ -16,10 +16,10 @@ logging messages.
 .SH "AUTHOR"
 The Tango team
 .SH "SEE ALSO"
-The full documentation for
-.B Tango
-is maintained as a pdf file.  If 
-.B Tango
-is properly installed at your site, this pdf file should be available in <tango_install_dir>/doc.
+The full documentation for \fBTango\fR is available at
+\fBhttps://tango-controls.readthedocs.io\fR.
+If \fBTango\fR is properly installed at your site,
+a copy of the documentation should be available in
+\fI/<install_prefix>/share/doc/tango\fR.
 You can also look at the Tango web site at 
-.B http://www.tango-controls.org.
+.B https://www.tango-controls.org.

--- a/assets/doc/man/pogo.1
+++ b/assets/doc/man/pogo.1
@@ -18,10 +18,10 @@ Documentation files will be written in the path given for \fIfile_name\fR.
 .SH "AUTHOR"
 The Tango team
 .SH "SEE ALSO"
-The full documentation for
-.B Tango
-is maintained as a pdf file.  If 
-.B Tango
-is properly installed at your site, this pdf file should be available in <tango_install_dir>/doc.
+The full documentation for \fBTango\fR is available at
+\fBhttps://tango-controls.readthedocs.io\fR.
+If \fBTango\fR is properly installed at your site,
+a copy of the documentation should be available in
+\fI/<install_prefix>/share/doc/tango\fR.
 You can also look at the Tango web site at 
-.B http://www.tango-controls.org.
+.B https://www.tango-controls.org.

--- a/assets/doc/man/synopticappli.1
+++ b/assets/doc/man/synopticappli.1
@@ -13,10 +13,10 @@ File describing the synoptic. If ommitted, a file chooser window pops-up.
 .SH "AUTHOR"
 The Tango team
 .SH "SEE ALSO"
-The full documentation for
-.B Tango
-is maintained as a pdf file.  If 
-.B Tango
-is properly installed at your site, this pdf file should be available in <tango_install_dir>/doc.
+The full documentation for \fBTango\fR is available at
+\fBhttps://tango-controls.readthedocs.io\fR.
+If \fBTango\fR is properly installed at your site,
+a copy of the documentation should be available in
+\fI/<install_prefix>/share/doc/tango\fR.
 You can also look at the Tango web site at 
-.B http://www.tango-controls.org.
+.B https://www.tango-controls.org.

--- a/build.xml
+++ b/build.xml
@@ -398,11 +398,32 @@
     <target name="-move-docs" depends="-fetch-docs">
         <move file="${workdir}/tango-${docs-ver}.pdf" todir="${distrdir}/doc"/>
     </target>
+
+    <target name="-fetch-docs-source">
+        <exec executable="git" dir="${workdir}" failonerror="true" failifexecutionfails="true">
+            <arg value="clone"/>
+            <arg line="--depth 1"/>
+            <arg line="-b ${tango-doc}"/>
+            <arg value="${src-root-repo}/tango-doc"/>
+            <arg value="tango-doc"/>
+        </exec>
+    </target>
+
+    <target name="-copy-docs-source" depends="-fetch-docs-source">
+        <copy todir="${distrdir}/doc/src/source">
+            <fileset dir="${workdir}/tango-doc/source"/>
+        </copy>
+        <copy todir="${distrdir}/doc/src">
+            <fileset file="${workdir}/tango-doc/Makefile"/>
+            <fileset file="${workdir}/tango-doc/requirements.txt"/>
+        </copy>
+    </target>
     <!-- Doc -->
 
 
     <target name="prepare-doc" depends="-mkdirs">
         <antcall target="-move-docs"/>
+        <antcall target="-copy-docs-source"/>
     </target>
 
     <target name="-fetch-tango_admin">

--- a/build.xml
+++ b/build.xml
@@ -396,6 +396,13 @@
             <arg value="${src-root-repo}/tango-doc"/>
             <arg value="tango-doc"/>
         </exec>
+        <delete>
+            <fileset dir="${workdir}/tango-doc/source">
+                <include name="**/*.pdf"/>
+                <include name="**/*.doc"/>
+                <include name="**/*.class"/>
+            </fileset>
+        </delete>
     </target>
 
     <target name="-copy-docs-source" depends="-fetch-docs-source">

--- a/build.xml
+++ b/build.xml
@@ -35,9 +35,6 @@
             <fileset dir="${basedir}/assets/doc">
                 <include name="Makefile.am"/>
             </fileset>
-            <filterset>
-                <filter token="DOCS_VER" value="${docs-ver}"/>
-            </filterset>
         </copy>
         <copy todir="${distrdir}/lib/java" overwrite="true">
             <fileset dir="${basedir}/assets/lib/java">
@@ -391,14 +388,6 @@
     </target>
 
     <!-- Doc -->
-    <target name="-fetch-docs">
-        <get src="${docs-root-repo}/${docs-ver}" dest="${workdir}/tango-${docs-ver}.pdf" skipexisting="true"/>
-    </target>
-
-    <target name="-move-docs" depends="-fetch-docs">
-        <move file="${workdir}/tango-${docs-ver}.pdf" todir="${distrdir}/doc"/>
-    </target>
-
     <target name="-fetch-docs-source">
         <exec executable="git" dir="${workdir}" failonerror="true" failifexecutionfails="true">
             <arg value="clone"/>
@@ -418,13 +407,21 @@
             <fileset file="${workdir}/tango-doc/requirements.txt"/>
         </copy>
     </target>
+
+    <target name="-build-docs" depends="-fetch-docs-source">
+        <exec executable="make" dir="${workdir}/tango-doc" failonerror="true" failifexecutionfails="true">
+            <arg value="singlehtml"/>
+        </exec>
+    </target>
+
+    <target name="-copy-docs" depends="-build-docs">
+        <copy todir="${distrdir}/doc/html">
+            <fileset dir="${workdir}/tango-doc/build/singlehtml"/>
+        </copy>
+    </target>
     <!-- Doc -->
 
-
-    <target name="prepare-doc" depends="-mkdirs">
-        <antcall target="-move-docs"/>
-        <antcall target="-copy-docs-source"/>
-    </target>
+    <target name="prepare-doc" depends="-mkdirs,-copy-docs-source,-copy-docs"/>
 
     <target name="-fetch-tango_admin">
         <exec executable="git" dir="${workdir}" failonerror="true" failifexecutionfails="true">
@@ -483,7 +480,7 @@
         <copy todir="${builddir}/package/tango-${cppTango}">
           <fileset dir="${builddir}/distr"/>
         </copy>
-        <tar compression="gzip" destfile="${builddir}/tango-${build}.tar.gz">
+        <tar compression="gzip" longfile="posix" destfile="${builddir}/tango-${build}.tar.gz">
             <tarfileset dir="${builddir}/package" filemode="755">
                 <include name="tango-${cppTango}/configure"/>
                 <include name="tango-${cppTango}/missing"/>

--- a/distribution.properties
+++ b/distribution.properties
@@ -34,3 +34,4 @@ docs-ver=9.2.5
 #utils
 tango_admin=Release_1.14
 #mtangorest.server=rc4-2.9
+tango-doc=9.3.3

--- a/distribution.properties
+++ b/distribution.properties
@@ -29,8 +29,6 @@ TangoTest=TangoTest-Release-2.1
 TangoDatabase=Database-Release-5.11
 TangoAccessControl=TangoAccessControl-Release-2.14
 starter=Starter-7.0
-#doc
-docs-ver=9.2.5
 #utils
 tango_admin=Release_1.14
 #mtangorest.server=rc4-2.9


### PR DESCRIPTION
This PR adds source of the docs back to tango source tarball.

Per [propsal](https://github.com/tango-controls/TangoSourceDistribution/issues/40#issuecomment-503738615) in #40, it is not integrated with autotools.