### PR TITLE
Run bootstrap for log4tango...

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -81,8 +81,6 @@
         <exec executable="/bin/bash" dir="${workdir}/cpp/log4tango" failonerror="true" failifexecutionfails="true">
             <arg value="${basedir}/bootstrap"/>
         </exec>
-        <exec executable="autoconf" dir="${workdir}/cpp/log4tango" failonerror="true" failifexecutionfails="true">
-        </exec>
     </target>
 
     <target name="-copy-cppTango" depends="-pre-copy-cppTango">

--- a/build.xml
+++ b/build.xml
@@ -78,6 +78,9 @@
             <arg value="1s/5\.0\.1/5.0.2/;18s/5:1:0/5:2:0/"/>
             <arg value="${workdir}/cpp/log4tango/configure.in"/>
         </exec>
+        <exec executable="/bin/bash" dir="${workdir}/cpp/log4tango" failonerror="true" failifexecutionfails="true">
+            <arg value="${basedir}/bootstrap"/>
+        </exec>
         <exec executable="autoconf" dir="${workdir}/cpp/log4tango" failonerror="true" failifexecutionfails="true">
         </exec>
     </target>


### PR DESCRIPTION
.. to avoid the following warning which could lead to unexpected behaviours:
aclocal.m4:17: warning: this file was generated for autoconf 2.68.
You have another version of autoconf.  It may work, but is not guaranteed to