### PR TITLE
Fix incorrect comparison brackets in configure script

### DIFF
--- a/assets/m4/ac_path_mariadb.m4
+++ b/assets/m4/ac_path_mariadb.m4
@@ -44,7 +44,7 @@ AC_ARG_WITH(mariadbclient-lib,AC_HELP_STRING([--with-mariadbclient-lib=LIB],[Dir
 			fi
 		done
 
-		for iloc in include/mariadb include; do
+		for iloc in include/mariadb include include/mysql; do
 			if test -f "$tryprefix/$iloc/mysql.h"; then
                 MARIADBCLIENT_CFLAGS="-I$tryprefix/$iloc"
             fi

--- a/assets/m4/mysql_release.m4
+++ b/assets/m4/mysql_release.m4
@@ -19,7 +19,7 @@ AC_DEFUN([mysql_AC_HAVE_MYSQL_VERSION],
 			 		MYSQL_MICRO=`echo $VERS | cut -d '.' -f 3`
 					MARIA=`echo $MYSQL_MICRO | cut -d '-' -f 2`
 
-					if [[ "$MARIA" == *aria* ]]; then
+					if [[[ "$MARIA" == *aria* ]]]; then
 						MYSQL_VERSION=not_found
 						ac_cv_mysql_version_$2_$3=no
 					else

--- a/assets/m4/mysql_release.m4
+++ b/assets/m4/mysql_release.m4
@@ -7,16 +7,16 @@ dnl                           MINOR_VERSION)
 dnl   
 
 AC_DEFUN([mysql_AC_HAVE_MYSQL_VERSION],
-	 [AC_CACHE_CHECK([for mysql release (at least version $2.$3)],
-	                 ac_cv_mysql_version_$2_$3,
-           [            
-			  if test -x $1; then
-			 		VERS=`$1 --version 2>&1 | cut -d ' ' -f 6 | cut -d ',' -f 1`
+	[AC_CACHE_CHECK([for mysql release (at least version $2.$3)],
+	                ac_cv_mysql_version_$2_$3,
+			[
+				if test -x $1; then
+					VERS=`$1 --version 2>&1 | cut -d ' ' -f 6 | cut -d ',' -f 1`
 					MYSQL_VERSION=$VERS
-					
-	         		MYSQL_MAJOR=`echo $VERS | cut -d '.' -f 1`
-			 		MYSQL_MINOR=`echo $VERS | cut -d '.' -f 2`
-			 		MYSQL_MICRO=`echo $VERS | cut -d '.' -f 3`
+
+					MYSQL_MAJOR=`echo $VERS | cut -d '.' -f 1`
+					MYSQL_MINOR=`echo $VERS | cut -d '.' -f 2`
+					MYSQL_MICRO=`echo $VERS | cut -d '.' -f 3`
 					MARIA=`echo $MYSQL_MICRO | cut -d '-' -f 2`
 
 					case "$MARIA" in
@@ -25,19 +25,19 @@ AC_DEFUN([mysql_AC_HAVE_MYSQL_VERSION],
 						ac_cv_mysql_version_$2_$3=no
 						;;
 					*)
-				 		if test $MYSQL_MAJOR -lt $2; then
+						if test $MYSQL_MAJOR -lt $2; then
 							ac_cv_mysql_version_$2_$3=no
-				 		else
+						else
 							if test $MYSQL_MINOR -lt $3; then
-					    		ac_cv_mysql_version_$2_$3=no
-				    	 	else
-					    		ac_cv_mysql_version_$2_$3=yes
-							fi			        
+								ac_cv_mysql_version_$2_$3=no
+							else
+								ac_cv_mysql_version_$2_$3=yes
+							fi
 						fi
 						;;
 					esac
 				else
 					ac_cv_mysql_version_$2_$3=no	
 				fi
-			])     
-     ])
+			])
+	])

--- a/assets/m4/mysql_release.m4
+++ b/assets/m4/mysql_release.m4
@@ -19,10 +19,12 @@ AC_DEFUN([mysql_AC_HAVE_MYSQL_VERSION],
 			 		MYSQL_MICRO=`echo $VERS | cut -d '.' -f 3`
 					MARIA=`echo $MYSQL_MICRO | cut -d '-' -f 2`
 
-					if [[[ "$MARIA" == *aria* ]]]; then
+					case "$MARIA" in
+					*aria*)
 						MYSQL_VERSION=not_found
 						ac_cv_mysql_version_$2_$3=no
-					else
+						;;
+					*)
 				 		if test $MYSQL_MAJOR -lt $2; then
 							ac_cv_mysql_version_$2_$3=no
 				 		else
@@ -32,7 +34,8 @@ AC_DEFUN([mysql_AC_HAVE_MYSQL_VERSION],
 					    		ac_cv_mysql_version_$2_$3=yes
 							fi			        
 						fi
-					fi
+						;;
+					esac
 				else
 					ac_cv_mysql_version_$2_$3=no	
 				fi


### PR DESCRIPTION
Fix incorrect comparison brackets (#9) 
Fix search path for mysql.h file when --enable-mariadb is used