### PR TITLE
Update JTango repo path

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -41,7 +41,7 @@
                 <include name="Makefile.am"/>
             </fileset>
             <filterset>
-                <filter token="JTANGO_JAR" value="${JTango}.jar"/>
+                <filter token="JTANGO_JAR" value="${JTango-jar}"/>
                 <filter token="ASTOR_JAR" value="${astor-jar}"/>
                 <filter token="ATK_CORE_JAR" value="${atk-core-jar}"/>
                 <filter token="ATK_WIDGET_JAR" value="${atk-widget-jar}"/>
@@ -190,12 +190,14 @@
         <mkdir dir="${distrdir}/utils"/>
     </target>
 
+    <property name="JTango-jar" value="JTango-${JTango-ver}.jar"/>
+    
     <target name="-fetch-JTango">
-        <get src="${jtango-root-repo}/${JTango-ver}/${JTango}.jar" dest="${workdir}/${JTango}.jar" skipexisting="true"/>
+        <get src="${jtango-root-repo}/${JTango-ver}/${JTango-jar}" dest="${workdir}/${JTango-jar}" skipexisting="true"/>
     </target>
 
     <target name="-move-JTango" depends="-fetch-JTango">
-        <move file="${workdir}/${JTango}.jar" todir="${distrdir}/lib/java"/>
+        <move file="${workdir}/${JTango-jar}" todir="${distrdir}/lib/java"/>
     </target>
 
     <!-- Jive -->

--- a/build.xml
+++ b/build.xml
@@ -191,7 +191,7 @@
     </target>
 
     <target name="-fetch-JTango">
-        <get src="${jtango-root-repo}=${JTango}.jar" dest="${workdir}/${JTango}.jar" skipexisting="true"/>
+        <get src="${jtango-root-repo}/${JTango-ver}/${JTango}.jar" dest="${workdir}/${JTango}.jar" skipexisting="true"/>
     </target>
 
     <target name="-move-JTango" depends="-fetch-JTango">

--- a/distribution.properties
+++ b/distribution.properties
@@ -11,7 +11,7 @@ rest-server-root-repo=https://github.com/tango-controls/rest-server/releases
 version-info=12:3:3
 #lib
 cppTango=9.3.3
-JTango=JTango-9.5.15
+JTango-ver=9.5.17
 tango-idl=5.0.1
 jive-ver=7.22
 atk-ver=9.3.6

--- a/distribution.properties
+++ b/distribution.properties
@@ -1,5 +1,5 @@
 src-root-repo=https://github.com/tango-controls
-jtango-root-repo=https://bintray.com/tango-controls/generic/download_file?file_path
+jtango-root-repo=https://github.com/tango-controls/JTango/releases/download/
 java-root-repo=https://bintray.com/tango-controls/maven/download_file?file_path
 docs-root-repo=https://readthedocs.org/projects/tango-controls/downloads/pdf
 rest-server-root-repo=https://github.com/tango-controls/rest-server/releases


### PR DESCRIPTION
Since [JTango#68](https://github.com/tango-controls/JTango/issues/68) JTango fat jar is uploaded to GitHub releases