### PR TITLE
assets/configure.ac: Check for zmq.hpp header

### DIFF
--- a/assets/configure.ac
+++ b/assets/configure.ac
@@ -196,6 +196,22 @@ ZMQ_VERSION=`eval pkg-config --modversion libzmq`
 ZMQ_ROOT=`eval pkg-config --variable=prefix libzmq`
 AC_SUBST(ZMQ_PREFIX)
 
+AC_LANG_SAVE
+AC_LANG_CPLUSPLUS
+SAVE_CXXFLAGS="$CXXFLAGS"
+CXXFLAGS="$CXXFLAGS -I $ZMQ_PREFIX/include"
+AC_CHECK_HEADERS(zmq.hpp, [], [AC_MSG_ERROR([Couldn't find a compatible zmq.hpp])],
+[#include <zmq.hpp>
+
+int main(int, char**)
+{
+  zmq::context_t c;
+  zmq::socket_t s(c, ZMQ_REQ);
+  s.disconnect("some endpoint");
+}])
+CXXFLAGS="$SAVE_CXXFLAGS"
+AC_LANG_RESTORE
+
 # We need to define some stuff for threads and stubs
 
 case $build_os in

--- a/assets/configure.ac
+++ b/assets/configure.ac
@@ -205,7 +205,7 @@ AC_CHECK_HEADERS(zmq.hpp, [], [AC_MSG_ERROR([Couldn't find a compatible zmq.hpp]
 
 int main(int, char**)
 {
-  zmq::context_t c;
+  zmq::context_t c(1);
   zmq::socket_t s(c, ZMQ_REQ);
   s.disconnect("some endpoint");
 }])


### PR DESCRIPTION
We do require the header for compilation but do currently not check for
it. The code snippet ensures that we get a recent
version with zmq::socket_t::disconnect method. This snipped is copied
from cppTango/6402affe (Use feature tests for checking if we have
zmq::socket::disconnect, 2019-10-23).

I'm not very familiar with autotools, but that works here.