### PR TITLE
Default to usr for omni checks

### DIFF
--- a/assets/m4/RSSH_CHECK_OMNINOTIFY.m4
+++ b/assets/m4/RSSH_CHECK_OMNINOTIFY.m4
@@ -29,7 +29,7 @@ fi
 
 if  test "x$OMNINOTIFY_PREFIX" = "xno"
 then
-dnl OMNINOTIFY NOT SET 
+dnl OMNINOTIFY NOT SET
   AC_MSG_RESULT(omniNotify is disabled)
   omninotify=no
 else
@@ -81,14 +81,14 @@ CXXCPPFLAGS="$CXXCPPFLAGS $IDLCXXFLAGS"
 
 AC_CHECK_HEADER( omniNotify/omniNotify.h, omninotify=yes , omninotify=no, )
 
-if test "x$omninotify" = "xyes" 
+if test "x$omninotify" = "xyes"
 then
   OMNI_LIBDIR="$OMNI_ROOT/lib"
   if test ! -r "$ORB_LIBDIR/libCOSNotify4.so"
   then
     for i in $OMNI_ROOT/lib/*/lib*.so
     do
-      OMNI_LIBDIR=`dirname $i` 
+      OMNI_LIBDIR=`dirname $i`
       break;
     done
   fi

--- a/assets/m4/RSSH_CHECK_OMNINOTIFY.m4
+++ b/assets/m4/RSSH_CHECK_OMNINOTIFY.m4
@@ -15,13 +15,13 @@ AC_REQUIRE([RSSH_CHECK_OMNIORB])dnl
 
 
 AC_ARG_WITH(omninotify, AC_HELP_STRING([--with-omniNotify],[prefix to omniNotify installation (default: $OMNI_ROOT)]) ,\
-            OMNINOTIFY_PREFIX=${with_omninotify} , OMNINOTIFY_PREFIX=/usr/local )
+            OMNINOTIFY_PREFIX=${with_omninotify} , OMNINOTIFY_PREFIX=/usr )
 
 if test "x$OMNI_ROOT" = "x"
 then
  if test "x$OMNINOTIFY_PREFIX" = "x"
  then
-   OMNI_ROOT="/usr/local"
+   OMNI_ROOT="/usr"
  else
    OMNI_ROOT="$OMNINOTIFY_PREFIX"
  fi

--- a/assets/m4/RSSH_CHECK_OMNIORB.m4
+++ b/assets/m4/RSSH_CHECK_OMNIORB.m4
@@ -1,4 +1,4 @@
-dnl@synposis RSSH_CHECK_CORBA_ORB 
+dnl@synposis RSSH_CHECK_CORBA_ORB
 dnl
 dnl set CORBA support for omniORB v3-pr2 or highter
 dnl    ( http://www.uk.research.att.com/omniORB/omniORB.html)
@@ -28,7 +28,7 @@ fi
 
 if  test "x$OMNI_PREFIX" = "xno"
 then
-dnl OMNI NOT SET 
+dnl OMNI NOT SET
   AC_MSG_RESULT(omniORB is disabled)
   omni=no
 else
@@ -66,7 +66,7 @@ case $build_os in
     AC_DEFINE(__darwin__,1,If we're running on darwin/MacOsX)
     IDLCXXFLAGS="$IDLCXXFLAGS -D__darwin__"
 	 SL_SUFFIX=dylib
-	 ;;	 
+	 ;;
  solaris*)
     AC_DEFINE(__sunos__,1,If we're running on solaris)
     IDLCXXFLAGS="$IDLCXXFLAGS -D__sunos__"
@@ -94,14 +94,14 @@ CXXCPPFLAGS="$CXXCPPFLAGS $IDLCXXFLAGS"
 
 AC_CHECK_HEADER( omniORB4/CORBA.h, omni=yes , omni=no, )
 
-if test "x$omni" = "xyes" 
+if test "x$omni" = "xyes"
 then
   ORB_LIBDIR="$OMNI_ROOT/lib"
   if test ! -r "$ORB_LIBDIR/libomniORB4.$SL_SUFFIX"
   then
     for i in $OMNI_ROOT/lib/*/lib*.$SL_SUFFIX
     do
-      ORB_LIBDIR=`dirname $i` 
+      ORB_LIBDIR=`dirname $i`
       break;
     done
   fi
@@ -197,7 +197,7 @@ then
   ORB=unknown
   omni=no
   eval "$rssh_rollback"
-  rssh_rollback=$svRSSH_ROLLBACK 
+  rssh_rollback=$svRSSH_ROLLBACK
 else
   AC_SUBST(CORBA_INCLUDES)
 
@@ -219,7 +219,7 @@ else
         IDL=$i
         break
       fi
-    done 
+    done
   fi
   AC_SUBST(IDL)
   IDLCXX=$IDL
@@ -251,8 +251,8 @@ else
   AC_SUBST(IDL_CLN_CPP_SUFFIX,$IDL_CLN_CPP_SUFFIX)
   AC_DEFINE_UNQUOTED(IDL_CLN_CPP_SUFFIX,$IDL_CLN_CPP,1,"")
 
-  IDL_CLN_O=SK.o 
-  IDL_CLN_OBJ_SUFFIX=SK.o 
+  IDL_CLN_O=SK.o
+  IDL_CLN_OBJ_SUFFIX=SK.o
   AC_SUBST(IDL_CLN_O,$IDL_CLN_O)
   AC_SUBST(IDL_CLN_OBJ_SUFFIX,$IDL_CLN_OBJ_SUFFIX)
 
@@ -288,7 +288,7 @@ else
   COSNAMING_H='omniORB4/Naming.hh'
   AC_DEFINE_UNQUOTED(COSNAMING_H,<$COSNAMING_H>, "")
 
-  ORB_COSNAMING_LIB= 
+  ORB_COSNAMING_LIB=
   AC_SUBST(ORB_COSNAMING_LIB)
 
 dnl i. e. it's build into ORB lib
@@ -310,13 +310,13 @@ return 0;
 ], rssh_cv_corba_namespaces=yes, rssh_cv_corba_namespaces=no)
   )
 
-  if test "$rssh_cv_corba_namespaces" = "yes" 
+  if test "$rssh_cv_corba_namespaces" = "yes"
   then
     AC_DEFINE(CORBA_MODULE_NAMESPACE_MAPPING,1, "")
   else
     AC_DEFINE(CORBA_MODULE_CLASS_MAPPING,1,"")
   fi
-  
+
   AC_DEFINE(OMNIORB,1,"if we're working with omniorb")
 
   CORBA_HAVE_POA=1

--- a/assets/m4/RSSH_CHECK_OMNIORB.m4
+++ b/assets/m4/RSSH_CHECK_OMNIORB.m4
@@ -14,13 +14,13 @@ AC_REQUIRE([AC_PROG_CXXCPP])
 
 
 AC_ARG_WITH(omni, AC_HELP_STRING([--with-omni],[prefix to omniORB installation (default: $OMNI_ROOT)]) ,\
-            OMNI_PREFIX=${with_omni} , OMNI_PREFIX=/usr/local )
+            OMNI_PREFIX=${with_omni} , OMNI_PREFIX=/usr )
 
 if test "x$OMNI_ROOT" = "x"
 then
  if test "x$OMNI_PREFIX" = "x"
  then
-   OMNI_ROOT="/usr/local"
+   OMNI_ROOT="/usr"
  else
    OMNI_ROOT="$OMNI_PREFIX"
  fi


### PR DESCRIPTION
   assets/m4/RSSH_CHECK_OMNI*.m4: Default to /usr for OMNI_ROOT
    
    We nowadays have a recent version of the omnitools available, so it does
    not make sense to search them in /usr/local by default.
    
    This also fixes the output of configure as it is prior to this commit
    
    OMNIORB PATH:     /usr/local
    OMNIORB VERSION:
    
    but after this commit we get
    
    OMNIORB PATH:     /usr
    OMNIORB VERSION:  "4.2.2"

What do you think?