### PR TITLE
.travis.yml: Fix broken build due to changes in tango-doc repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_script:
       libmysqlclient-dev
       ant
   - sudo apt install -y python python-pip
-  - pip install --user Sphinx~=1.0 ipython~=5.0
+  - pip install -r https://raw.githubusercontent.com/tango-controls/tango-doc/9.3.4/requirements.txt
 script:
   - ant build package
 


### PR DESCRIPTION
The required python packages changed in c409572d (#308, #314 - adding
sphinx_rtd_theme as a requirement., 2020-01-22) in the tango-doc
repository. But that change was not reflected in the CI setup here.

Let's us their requirements.txt from the 9.3.4 branch in order to always
avoid similiar breakages in the future.

Close #72.