### PR TITLE
Update TangoTest to Release 3.1

### DIFF
--- a/distribution.properties
+++ b/distribution.properties
@@ -25,7 +25,7 @@ pogo-ver=9.6.31
 rest-server-ver=1.22
 #tool_panels=
 #cppserver
-TangoTest=3.0
+TangoTest=3.1
 TangoDatabase=Database-Release-5.16
 TangoAccessControl=TangoAccessControl-Release-2.15
 starter=Starter-7.3


### PR DESCRIPTION
TangoTest: A potential crash in write_long_image has been fixed 
(https://github.com/tango-controls/TangoTest/issues/13, https://github.com/tango-controls/TangoTest/pull/14).
To be consistent, the same fix has been applied on write_xxx_spectrum and write_xxx_image methods.